### PR TITLE
feat: add 2D Canvas battlespace visualization

### DIFF
--- a/apps/web/src/components/simulation/BattlespaceCanvas.tsx
+++ b/apps/web/src/components/simulation/BattlespaceCanvas.tsx
@@ -27,6 +27,7 @@ function hexToRgb(hex: string): [number, number, number] {
 // Grid layout: 4 columns x 2 rows
 const COLS = 4;
 const ROWS = 2;
+const ZONE_PAD = 3;
 
 // Short labels for compact display
 const SHORT_LABELS: Record<DomainLayer, string> = {
@@ -38,6 +39,17 @@ const SHORT_LABELS: Record<DomainLayer, string> = {
   [DomainLayer.SpacePnt]: "SPC",
   [DomainLayer.InformationCognitive]: "INF",
   [DomainLayer.DomesticPoliticalFiscal]: "POL",
+};
+
+const DOMAIN_FULL_LABELS: Record<DomainLayer, string> = {
+  [DomainLayer.Kinetic]: "Kinetic",
+  [DomainLayer.MaritimeLogistics]: "Maritime",
+  [DomainLayer.Energy]: "Energy",
+  [DomainLayer.GeoeconomicIndustrial]: "Geoeconomic",
+  [DomainLayer.Cyber]: "Cyber",
+  [DomainLayer.SpacePnt]: "Space/PNT",
+  [DomainLayer.InformationCognitive]: "Info/Cogn",
+  [DomainLayer.DomesticPoliticalFiscal]: "Domestic",
 };
 
 export default function BattlespaceCanvas({
@@ -79,7 +91,7 @@ export default function BattlespaceCanvas({
     const cellH = displayHeight / ROWS;
 
     // 1. Background
-    ctx.fillStyle = "#111";
+    ctx.fillStyle = "#0c0c0c";
     ctx.fillRect(0, 0, displayWidth, displayHeight);
 
     // Phase-tinted background overlay
@@ -91,29 +103,36 @@ export default function BattlespaceCanvas({
       ctx.fillRect(0, 0, displayWidth, displayHeight);
     }
 
-    // 2. Grid lines
-    ctx.strokeStyle = "#1a1a1a";
-    ctx.lineWidth = 0.5;
-    for (let c = 0; c <= COLS; c++) {
-      const x = c * cellW;
-      ctx.beginPath();
-      ctx.moveTo(x, 0);
-      ctx.lineTo(x, displayHeight);
-      ctx.stroke();
-    }
-    for (let r = 0; r <= ROWS; r++) {
-      const y = r * cellH;
-      ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(displayWidth, y);
-      ctx.stroke();
-    }
-
     if (!worldState) {
-      // Empty state label
-      ctx.fillStyle = "#555";
-      ctx.font = "12px monospace";
+      // Empty state — draw zone outlines as structural skeleton
+      ALL_DOMAINS.forEach((domain, idx) => {
+        const col = idx % COLS;
+        const row = Math.floor(idx / COLS);
+        const x = col * cellW;
+        const y = row * cellH;
+
+        // Dim zone fill
+        const [dr, dg, db] = hexToRgb(DOMAIN_COLORS[domain]);
+        ctx.fillStyle = `rgba(${dr},${dg},${db},0.08)`;
+        ctx.fillRect(x + ZONE_PAD, y + ZONE_PAD, cellW - ZONE_PAD * 2, cellH - ZONE_PAD * 2);
+
+        // Border
+        ctx.strokeStyle = `rgba(${dr},${dg},${db},0.3)`;
+        ctx.lineWidth = 1;
+        ctx.strokeRect(x + ZONE_PAD, y + ZONE_PAD, cellW - ZONE_PAD * 2, cellH - ZONE_PAD * 2);
+
+        // Label
+        ctx.fillStyle = "rgba(160,160,160,0.5)";
+        ctx.font = "bold 10px monospace";
+        ctx.textAlign = "left";
+        ctx.textBaseline = "top";
+        ctx.fillText(SHORT_LABELS[domain], x + ZONE_PAD + 4, y + ZONE_PAD + 4);
+      });
+
+      ctx.fillStyle = "#444";
+      ctx.font = "11px monospace";
       ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
       ctx.fillText(
         "Awaiting world state\u2026",
         displayWidth / 2,
@@ -127,61 +146,76 @@ export default function BattlespaceCanvas({
     // Zone center coordinates for coupling lines
     const zoneCenters: Record<string, [number, number]> = {};
 
-    // 3. Domain zones
+    // 2. Domain zones
     ALL_DOMAINS.forEach((domain, idx) => {
       const col = idx % COLS;
       const row = Math.floor(idx / COLS);
       const x = col * cellW;
       const y = row * cellH;
+      const zx = x + ZONE_PAD;
+      const zy = y + ZONE_PAD;
+      const zw = cellW - ZONE_PAD * 2;
+      const zh = cellH - ZONE_PAD * 2;
       const layer = layers[domain];
 
       const cx = x + cellW / 2;
       const cy = y + cellH / 2;
       zoneCenters[domain] = [cx, cy];
 
-      // Zone fill: domain color at stress-driven alpha
       const [dr, dg, db] = hexToRgb(DOMAIN_COLORS[domain]);
-      const fillAlpha = 0.15 + layer.stress * 0.85;
-      ctx.fillStyle = `rgba(${dr},${dg},${db},${fillAlpha})`;
-      ctx.fillRect(x + 1, y + 1, cellW - 2, cellH - 2);
 
-      // Resilience border
-      const borderWidth = 1 + layer.resilience * 4;
-      ctx.strokeStyle = DOMAIN_COLORS[domain];
+      // Zone fill: domain color with minimum visibility + stress-driven intensity
+      const fillAlpha = 0.12 + layer.stress * 0.75;
+      ctx.fillStyle = `rgba(${dr},${dg},${db},${fillAlpha})`;
+      ctx.fillRect(zx, zy, zw, zh);
+
+      // Inner glow — brighter bar at bottom proportional to stress
+      if (layer.stress > 0.01) {
+        const barH = Math.max(2, zh * layer.stress * 0.3);
+        ctx.fillStyle = `rgba(${dr},${dg},${db},${0.3 + layer.stress * 0.5})`;
+        ctx.fillRect(zx, zy + zh - barH, zw, barH);
+      }
+
+      // Resilience border — always visible, thickness scales with resilience
+      const borderAlpha = 0.35 + layer.resilience * 0.65;
+      const borderWidth = 1 + layer.resilience * 3;
+      ctx.strokeStyle = `rgba(${dr},${dg},${db},${borderAlpha})`;
       ctx.lineWidth = borderWidth;
       ctx.strokeRect(
-        x + borderWidth / 2,
-        y + borderWidth / 2,
-        cellW - borderWidth,
-        cellH - borderWidth
+        zx + borderWidth / 2,
+        zy + borderWidth / 2,
+        zw - borderWidth,
+        zh - borderWidth
       );
 
-      // Activity particles
-      const particleCount = Math.floor(layer.activity_level * 20);
-      ctx.fillStyle = "rgba(255,255,255,0.4)";
+      // Activity particles — minimum 2 so zones always look "alive"
+      const particleCount = Math.max(2, Math.floor(layer.activity_level * 25));
+      const particleAlpha = 0.2 + layer.activity_level * 0.4;
+      ctx.fillStyle = `rgba(255,255,255,${particleAlpha})`;
       for (let i = 0; i < particleCount; i++) {
         const seed = turn * 1000 + idx * 100 + i;
-        const px = x + 4 + seededRandom(seed) * (cellW - 8);
-        const py = y + 4 + seededRandom(seed + 7) * (cellH - 8);
-        const size = 2 + seededRandom(seed + 13);
+        const px = zx + 6 + seededRandom(seed) * (zw - 12);
+        const py = zy + 18 + seededRandom(seed + 7) * (zh - 24);
+        const size = 1.5 + seededRandom(seed + 13) * 1.5;
         ctx.fillRect(px, py, size, size);
       }
 
       // Friction hatching
-      if (layer.friction > 0.3) {
+      if (layer.friction > 0.2) {
         ctx.save();
         ctx.beginPath();
-        ctx.rect(x, y, cellW, cellH);
+        ctx.rect(zx, zy, zw, zh);
         ctx.clip();
 
-        ctx.strokeStyle = `rgba(255,255,255,0.15)`;
+        const hatchAlpha = 0.06 + layer.friction * 0.12;
+        ctx.strokeStyle = `rgba(255,255,255,${hatchAlpha})`;
         ctx.lineWidth = 0.5;
-        const spacing = 8;
-        const diag = cellW + cellH;
+        const spacing = 6;
+        const diag = zw + zh;
         for (let d = -diag; d < diag; d += spacing) {
           ctx.beginPath();
-          ctx.moveTo(x + d, y);
-          ctx.lineTo(x + d + cellH, y + cellH);
+          ctx.moveTo(zx + d, zy);
+          ctx.lineTo(zx + d + zh, zy + zh);
           ctx.stroke();
         }
         ctx.restore();
@@ -190,21 +224,41 @@ export default function BattlespaceCanvas({
       // Turn flash: highlight domains with significant stress change
       if (previousWorldState) {
         const prevLayer = previousWorldState.layers[domain];
-        if (prevLayer && Math.abs(layer.stress - prevLayer.stress) > 0.05) {
-          ctx.fillStyle = "rgba(255,255,255,0.15)";
-          ctx.fillRect(x + 1, y + 1, cellW - 2, cellH - 2);
+        if (prevLayer && Math.abs(layer.stress - prevLayer.stress) > 0.03) {
+          const flashAlpha = Math.min(0.25, Math.abs(layer.stress - prevLayer.stress) * 0.8);
+          ctx.fillStyle = `rgba(255,255,255,${flashAlpha})`;
+          ctx.fillRect(zx, zy, zw, zh);
         }
       }
+
+      // Domain label — short code top-left, full name below
+      ctx.textAlign = "left";
+      ctx.textBaseline = "top";
+      ctx.font = "bold 10px monospace";
+      ctx.fillStyle = `rgba(${dr},${dg},${db},0.9)`;
+      ctx.fillText(SHORT_LABELS[domain], zx + 4, zy + 4);
+
+      ctx.font = "8px monospace";
+      ctx.fillStyle = "rgba(180,180,180,0.5)";
+      ctx.fillText(DOMAIN_FULL_LABELS[domain], zx + 4, zy + 16);
+
+      // Stress value readout bottom-right
+      const stressPct = (layer.stress * 100).toFixed(0);
+      ctx.textAlign = "right";
+      ctx.textBaseline = "bottom";
+      ctx.font = "9px monospace";
+      ctx.fillStyle = `rgba(${dr},${dg},${db},0.7)`;
+      ctx.fillText(`${stressPct}%`, zx + zw - 4, zy + zh - 4);
     });
 
-    // 4. Coupling lines
+    // 3. Coupling lines
     if (coupling_matrix) {
       const drawn = new Set<string>();
       for (const domA of Object.keys(coupling_matrix)) {
-        const row = coupling_matrix[domA];
-        if (!row) continue;
-        for (const domB of Object.keys(row)) {
-          const weight = row[domB];
+        const rowData = coupling_matrix[domA];
+        if (!rowData) continue;
+        for (const domB of Object.keys(rowData)) {
+          const weight = rowData[domB];
           if (weight <= 0.01) continue;
           const key = [domA, domB].sort().join("|");
           if (drawn.has(key)) continue;
@@ -214,8 +268,8 @@ export default function BattlespaceCanvas({
           const b = zoneCenters[domB];
           if (!a || !b) continue;
 
-          ctx.strokeStyle = `rgba(74,78,105,${0.2 + weight * 0.5})`;
-          ctx.lineWidth = 0.5 + weight * 3;
+          ctx.strokeStyle = `rgba(100,110,140,${0.15 + weight * 0.4})`;
+          ctx.lineWidth = 0.5 + weight * 2.5;
           ctx.beginPath();
           ctx.moveTo(a[0], a[1]);
           ctx.lineTo(b[0], b[1]);
@@ -223,19 +277,6 @@ export default function BattlespaceCanvas({
         }
       }
     }
-
-    // 5. Domain labels
-    ctx.textAlign = "left";
-    ctx.textBaseline = "top";
-    ctx.font = "9px monospace";
-    ALL_DOMAINS.forEach((domain, idx) => {
-      const col = idx % COLS;
-      const row = Math.floor(idx / COLS);
-      const x = col * cellW + 4;
-      const y = row * cellH + 3;
-      ctx.fillStyle = "rgba(204,204,204,0.7)";
-      ctx.fillText(SHORT_LABELS[domain], x, y);
-    });
   }, [worldState, previousWorldState, containerWidth]);
 
   return (

--- a/apps/web/src/components/simulation/BattlespaceCanvas.tsx
+++ b/apps/web/src/components/simulation/BattlespaceCanvas.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ALL_DOMAINS,
   DOMAIN_COLORS,
-  DOMAIN_LABELS,
   DomainLayer,
 } from "../../types/domain";
 import { WorldState } from "../../types/run";
@@ -45,24 +44,33 @@ export default function BattlespaceCanvas({
   worldState,
   previousWorldState,
 }: BattlespaceCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  // Track container width via ResizeObserver so we re-render on layout
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      if (w > 0) setContainerWidth(w);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    if (!canvas || containerWidth === 0) return;
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    const parent = canvas.parentElement;
-    if (!parent) return;
-
     // DPR-aware sizing
     const dpr = window.devicePixelRatio || 1;
-    const displayWidth = parent.clientWidth;
+    const displayWidth = containerWidth;
     const displayHeight = Math.floor(displayWidth / 2); // 2:1 aspect ratio
-    canvas.style.width = `${displayWidth}px`;
-    canvas.style.height = `${displayHeight}px`;
     canvas.width = displayWidth * dpr;
     canvas.height = displayHeight * dpr;
     ctx.scale(dpr, dpr);
@@ -228,16 +236,21 @@ export default function BattlespaceCanvas({
       ctx.fillStyle = "rgba(204,204,204,0.7)";
       ctx.fillText(SHORT_LABELS[domain], x, y);
     });
-  }, [worldState, previousWorldState]);
+  }, [worldState, previousWorldState, containerWidth]);
 
   return (
-    <canvas
-      ref={canvasRef}
-      style={{
-        display: "block",
-        imageRendering: "pixelated",
-        width: "100%",
-      }}
-    />
+    <div ref={containerRef} style={{ width: "100%" }}>
+      {containerWidth > 0 && (
+        <canvas
+          ref={canvasRef}
+          style={{
+            display: "block",
+            imageRendering: "pixelated",
+            width: containerWidth,
+            height: Math.floor(containerWidth / 2),
+          }}
+        />
+      )}
+    </div>
   );
 }

--- a/apps/web/src/components/simulation/BattlespaceCanvas.tsx
+++ b/apps/web/src/components/simulation/BattlespaceCanvas.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useRef } from "react";
+import {
+  ALL_DOMAINS,
+  DOMAIN_COLORS,
+  DOMAIN_LABELS,
+  DomainLayer,
+} from "../../types/domain";
+import { WorldState } from "../../types/run";
+import { PHASE_COLORS } from "../../types/phase";
+
+interface BattlespaceCanvasProps {
+  worldState: WorldState | null;
+  previousWorldState: WorldState | null;
+}
+
+/** Simple seeded PRNG for stable particle positions. */
+function seededRandom(seed: number): number {
+  const x = Math.sin(seed * 9301 + 49297) * 233280;
+  return x - Math.floor(x);
+}
+
+/** Parse hex color "#rrggbb" to [r, g, b]. */
+function hexToRgb(hex: string): [number, number, number] {
+  const v = parseInt(hex.slice(1), 16);
+  return [(v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
+}
+
+// Grid layout: 4 columns x 2 rows
+const COLS = 4;
+const ROWS = 2;
+
+// Short labels for compact display
+const SHORT_LABELS: Record<DomainLayer, string> = {
+  [DomainLayer.Kinetic]: "KIN",
+  [DomainLayer.MaritimeLogistics]: "MAR",
+  [DomainLayer.Energy]: "NRG",
+  [DomainLayer.GeoeconomicIndustrial]: "GEO",
+  [DomainLayer.Cyber]: "CYB",
+  [DomainLayer.SpacePnt]: "SPC",
+  [DomainLayer.InformationCognitive]: "INF",
+  [DomainLayer.DomesticPoliticalFiscal]: "POL",
+};
+
+export default function BattlespaceCanvas({
+  worldState,
+  previousWorldState,
+}: BattlespaceCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const parent = canvas.parentElement;
+    if (!parent) return;
+
+    // DPR-aware sizing
+    const dpr = window.devicePixelRatio || 1;
+    const displayWidth = parent.clientWidth;
+    const displayHeight = Math.floor(displayWidth / 2); // 2:1 aspect ratio
+    canvas.style.width = `${displayWidth}px`;
+    canvas.style.height = `${displayHeight}px`;
+    canvas.width = displayWidth * dpr;
+    canvas.height = displayHeight * dpr;
+    ctx.scale(dpr, dpr);
+
+    const cellW = displayWidth / COLS;
+    const cellH = displayHeight / ROWS;
+
+    // 1. Background
+    ctx.fillStyle = "#111";
+    ctx.fillRect(0, 0, displayWidth, displayHeight);
+
+    // Phase-tinted background overlay
+    if (worldState) {
+      const phaseColor = PHASE_COLORS[worldState.phase];
+      const [r, g, b] = hexToRgb(phaseColor);
+      const alpha = Math.min(0.15, worldState.order_parameter * 0.2);
+      ctx.fillStyle = `rgba(${r},${g},${b},${alpha})`;
+      ctx.fillRect(0, 0, displayWidth, displayHeight);
+    }
+
+    // 2. Grid lines
+    ctx.strokeStyle = "#1a1a1a";
+    ctx.lineWidth = 0.5;
+    for (let c = 0; c <= COLS; c++) {
+      const x = c * cellW;
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, displayHeight);
+      ctx.stroke();
+    }
+    for (let r = 0; r <= ROWS; r++) {
+      const y = r * cellH;
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(displayWidth, y);
+      ctx.stroke();
+    }
+
+    if (!worldState) {
+      // Empty state label
+      ctx.fillStyle = "#555";
+      ctx.font = "12px monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(
+        "Awaiting world state\u2026",
+        displayWidth / 2,
+        displayHeight / 2
+      );
+      return;
+    }
+
+    const { layers, turn, coupling_matrix } = worldState;
+
+    // Zone center coordinates for coupling lines
+    const zoneCenters: Record<string, [number, number]> = {};
+
+    // 3. Domain zones
+    ALL_DOMAINS.forEach((domain, idx) => {
+      const col = idx % COLS;
+      const row = Math.floor(idx / COLS);
+      const x = col * cellW;
+      const y = row * cellH;
+      const layer = layers[domain];
+
+      const cx = x + cellW / 2;
+      const cy = y + cellH / 2;
+      zoneCenters[domain] = [cx, cy];
+
+      // Zone fill: domain color at stress-driven alpha
+      const [dr, dg, db] = hexToRgb(DOMAIN_COLORS[domain]);
+      const fillAlpha = 0.15 + layer.stress * 0.85;
+      ctx.fillStyle = `rgba(${dr},${dg},${db},${fillAlpha})`;
+      ctx.fillRect(x + 1, y + 1, cellW - 2, cellH - 2);
+
+      // Resilience border
+      const borderWidth = 1 + layer.resilience * 4;
+      ctx.strokeStyle = DOMAIN_COLORS[domain];
+      ctx.lineWidth = borderWidth;
+      ctx.strokeRect(
+        x + borderWidth / 2,
+        y + borderWidth / 2,
+        cellW - borderWidth,
+        cellH - borderWidth
+      );
+
+      // Activity particles
+      const particleCount = Math.floor(layer.activity_level * 20);
+      ctx.fillStyle = "rgba(255,255,255,0.4)";
+      for (let i = 0; i < particleCount; i++) {
+        const seed = turn * 1000 + idx * 100 + i;
+        const px = x + 4 + seededRandom(seed) * (cellW - 8);
+        const py = y + 4 + seededRandom(seed + 7) * (cellH - 8);
+        const size = 2 + seededRandom(seed + 13);
+        ctx.fillRect(px, py, size, size);
+      }
+
+      // Friction hatching
+      if (layer.friction > 0.3) {
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(x, y, cellW, cellH);
+        ctx.clip();
+
+        ctx.strokeStyle = `rgba(255,255,255,0.15)`;
+        ctx.lineWidth = 0.5;
+        const spacing = 8;
+        const diag = cellW + cellH;
+        for (let d = -diag; d < diag; d += spacing) {
+          ctx.beginPath();
+          ctx.moveTo(x + d, y);
+          ctx.lineTo(x + d + cellH, y + cellH);
+          ctx.stroke();
+        }
+        ctx.restore();
+      }
+
+      // Turn flash: highlight domains with significant stress change
+      if (previousWorldState) {
+        const prevLayer = previousWorldState.layers[domain];
+        if (prevLayer && Math.abs(layer.stress - prevLayer.stress) > 0.05) {
+          ctx.fillStyle = "rgba(255,255,255,0.15)";
+          ctx.fillRect(x + 1, y + 1, cellW - 2, cellH - 2);
+        }
+      }
+    });
+
+    // 4. Coupling lines
+    if (coupling_matrix) {
+      const drawn = new Set<string>();
+      for (const domA of Object.keys(coupling_matrix)) {
+        const row = coupling_matrix[domA];
+        if (!row) continue;
+        for (const domB of Object.keys(row)) {
+          const weight = row[domB];
+          if (weight <= 0.01) continue;
+          const key = [domA, domB].sort().join("|");
+          if (drawn.has(key)) continue;
+          drawn.add(key);
+
+          const a = zoneCenters[domA];
+          const b = zoneCenters[domB];
+          if (!a || !b) continue;
+
+          ctx.strokeStyle = `rgba(74,78,105,${0.2 + weight * 0.5})`;
+          ctx.lineWidth = 0.5 + weight * 3;
+          ctx.beginPath();
+          ctx.moveTo(a[0], a[1]);
+          ctx.lineTo(b[0], b[1]);
+          ctx.stroke();
+        }
+      }
+    }
+
+    // 5. Domain labels
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    ctx.font = "9px monospace";
+    ALL_DOMAINS.forEach((domain, idx) => {
+      const col = idx % COLS;
+      const row = Math.floor(idx / COLS);
+      const x = col * cellW + 4;
+      const y = row * cellH + 3;
+      ctx.fillStyle = "rgba(204,204,204,0.7)";
+      ctx.fillText(SHORT_LABELS[domain], x, y);
+    });
+  }, [worldState, previousWorldState]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        display: "block",
+        imageRendering: "pixelated",
+        width: "100%",
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -12,6 +12,7 @@ import EventFeed from "./EventFeed";
 import MetricsOverview from "./MetricsOverview";
 import ActionPanel from "./ActionPanel";
 import AiMovePanel from "../../components/ai/AiMovePanel";
+import BattlespaceCanvas from "./BattlespaceCanvas";
 import DomainStressChart from "./DomainStressChart";
 import AfterActionReport, { DomainDelta, computeDomainDeltas } from "./AfterActionReport";
 import Dialog from "../common/Dialog";
@@ -286,6 +287,12 @@ export default function SimulationDashboard({
           </div>
 
           <div className="sim-layout__center">
+            <div className="battlespace-canvas">
+              <BattlespaceCanvas
+                worldState={worldState}
+                previousWorldState={prevWorldStateRef.current}
+              />
+            </div>
             <MetricsOverview
               orderParameter={orderParameter}
               phase={currentPhase}

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -1893,3 +1893,11 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
   border-radius: 4px;
   font-size: 0.85rem;
 }
+
+.battlespace-canvas {
+  width: 100%;
+  aspect-ratio: 2 / 1;
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: #111;
+}


### PR DESCRIPTION
## Summary

- Adds a new `BattlespaceCanvas` component inspired by rot-garden's 2D Canvas terrarium aesthetic
- Renders the 8 domain layers as a 4x2 spatial grid where visual properties reflect game state: stress drives brightness, resilience controls border thickness, activity spawns particles, friction adds hatching
- Coupling lines connect domains, background tints with phase color as the order parameter rises
- Integrated at the top of the center panel in SimulationDashboard, updating each turn

## Test plan

- [ ] Verify the canvas renders correctly on the simulation dashboard with an active run
- [ ] Confirm domain zones change appearance as stress/resilience/activity values shift between turns
- [ ] Check coupling lines appear between domains with non-trivial coupling weights
- [ ] Verify background color shifts subtly as the order parameter increases
- [ ] Test responsive behavior when resizing the browser window
- [ ] Confirm the canvas shows "Awaiting world state…" before data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)