### PR TITLE
fix: resolve pre-existing CI failures

### DIFF
--- a/apps/api/app/routers/replay.py
+++ b/apps/api/app/routers/replay.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.schemas.event import EventList, EventRead
+from app.schemas.event import EventList
 from app.services.engine_bridge import EngineBridge
 from app.services.replay_service import ReplayService
 

--- a/apps/api/app/services/narrative_service.py
+++ b/apps/api/app/services/narrative_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import random
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 

--- a/apps/api/app/services/narrator.py
+++ b/apps/api/app/services/narrator.py
@@ -394,7 +394,7 @@ def generate_turn_narrative(
     phase = turn_result.get("phase", "CompetitiveNormality")
     order_param = turn_result.get("order_parameter", 0.0)
     events = turn_result.get("events", [])
-    effects = turn_result.get("effects", [])
+    _ = turn_result.get("effects", [])
     phase_changed = turn_result.get("phase_changed", False)
     previous_phase = turn_result.get("previous_phase")
 

--- a/apps/api/app/tests/test_engine_bridge.py
+++ b/apps/api/app/tests/test_engine_bridge.py
@@ -1,9 +1,8 @@
 """Tests for the engine bridge with mock subprocess."""
 
-import asyncio
 import json
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: "./src/test-setup.ts",
+    exclude: ["e2e/**", "node_modules/**"],
   },
 });

--- a/services/sim-engine/src/action.rs
+++ b/services/sim-engine/src/action.rs
@@ -150,7 +150,10 @@ mod tests {
 
     #[test]
     fn test_action_type_min_phase() {
-        assert_eq!(ActionType::Escalate.min_phase(), Phase::CompetitiveNormality);
+        assert_eq!(
+            ActionType::Escalate.min_phase(),
+            Phase::CompetitiveNormality
+        );
         assert_eq!(ActionType::MilitaryDeploy.min_phase(), Phase::WarTransition);
         assert_eq!(ActionType::CyberAttack.min_phase(), Phase::HybridCoercion);
     }

--- a/services/sim-engine/src/actor.rs
+++ b/services/sim-engine/src/actor.rs
@@ -136,8 +136,8 @@ mod tests {
 
     #[test]
     fn test_actor_serialization() {
-        let actor = Actor::new("Test", ActorKind::Alliance)
-            .with_capability(DomainLayer::Cyber, 0.5);
+        let actor =
+            Actor::new("Test", ActorKind::Alliance).with_capability(DomainLayer::Cyber, 0.5);
         let json = serde_json::to_string(&actor).unwrap();
         let deser: Actor = serde_json::from_str(&json).unwrap();
         assert_eq!(deser.name, "Test");

--- a/services/sim-engine/src/coupling.rs
+++ b/services/sim-engine/src/coupling.rs
@@ -26,7 +26,11 @@ impl Serialize for CouplingMatrix {
             .couplings
             .iter()
             .filter(|((a, b), _)| *a <= *b) // only one direction to avoid duplicates
-            .map(|((a, b), &s)| CouplingEntry { a: *a, b: *b, strength: s })
+            .map(|((a, b), &s)| CouplingEntry {
+                a: *a,
+                b: *b,
+                strength: s,
+            })
             .collect();
         let mut state = serializer.serialize_struct("CouplingMatrix", 2)?;
         state.serialize_field("couplings", &entries)?;
@@ -154,7 +158,10 @@ mod tests {
         let m = default_coupling_matrix();
         // DomesticPolitical <-> SpacePnt is not explicitly set, should be 0.2
         assert_eq!(
-            m.get(&DomainLayer::DomesticPoliticalFiscal, &DomainLayer::SpacePnt),
+            m.get(
+                &DomainLayer::DomesticPoliticalFiscal,
+                &DomainLayer::SpacePnt
+            ),
             0.2
         );
     }
@@ -170,7 +177,9 @@ mod tests {
             LayerState::new(0.1, 0.5, 0.1, 0.2),
         );
         for d in DomainLayer::ALL {
-            layers.entry(d).or_insert_with(|| LayerState::new(0.0, 0.5, 0.1, 0.1));
+            layers
+                .entry(d)
+                .or_insert_with(|| LayerState::new(0.0, 0.5, 0.1, 0.1));
         }
 
         let initial_maritime = layers[&DomainLayer::MaritimeLogistics].stress;
@@ -193,10 +202,8 @@ mod tests {
             layers.insert(d, LayerState::new(0.2, 0.5, 0.1, 0.1));
         }
 
-        let initial: HashMap<DomainLayer, f64> = layers
-            .iter()
-            .map(|(d, l)| (*d, l.stress))
-            .collect();
+        let initial: HashMap<DomainLayer, f64> =
+            layers.iter().map(|(d, l)| (*d, l.stress)).collect();
         m.propagate_stress(&mut layers);
 
         for d in DomainLayer::ALL {
@@ -212,9 +219,6 @@ mod tests {
         let m = default_coupling_matrix();
         let json = serde_json::to_string(&m).unwrap();
         let deser: CouplingMatrix = serde_json::from_str(&json).unwrap();
-        assert_eq!(
-            deser.get(&DomainLayer::Kinetic, &DomainLayer::Energy),
-            0.5
-        );
+        assert_eq!(deser.get(&DomainLayer::Kinetic, &DomainLayer::Energy), 0.5);
     }
 }

--- a/services/sim-engine/src/domain.rs
+++ b/services/sim-engine/src/domain.rs
@@ -111,8 +111,7 @@ mod tests {
 
     #[test]
     fn test_layer_state_with_variable() {
-        let ls = LayerState::new(0.1, 0.5, 0.1, 0.2)
-            .with_variable("troop_count", 1000.0);
+        let ls = LayerState::new(0.1, 0.5, 0.1, 0.2).with_variable("troop_count", 1000.0);
         assert_eq!(ls.variables.get("troop_count"), Some(&1000.0));
     }
 

--- a/services/sim-engine/src/engine.rs
+++ b/services/sim-engine/src/engine.rs
@@ -187,9 +187,15 @@ impl SimulationEngine {
                 }
 
                 let mut param_ranges = HashMap::new();
-                param_ranges.insert("intensity".into(), (0.1, actor.capability(
-                    available_layers.first().unwrap_or(&DomainLayer::Kinetic),
-                ).max(0.1)));
+                param_ranges.insert(
+                    "intensity".into(),
+                    (
+                        0.1,
+                        actor
+                            .capability(available_layers.first().unwrap_or(&DomainLayer::Kinetic))
+                            .max(0.1),
+                    ),
+                );
 
                 let description = format!(
                     "{:?} by {} on {:?}",
@@ -291,7 +297,12 @@ impl SimulationEngine {
 
         // Deduct resources
         let cost = action.action_type.resource_cost();
-        if let Some(actor) = self.state.actors.iter_mut().find(|a| a.id == action.actor_id) {
+        if let Some(actor) = self
+            .state
+            .actors
+            .iter_mut()
+            .find(|a| a.id == action.actor_id)
+        {
             actor.resources -= cost;
         }
 
@@ -428,7 +439,10 @@ impl SimulationEngine {
                         layer: DomainLayer::Cyber,
                         field: "stress".into(),
                         delta: stress_delta,
-                        description: format!("Cyber attack increased stress by {:.4}", stress_delta),
+                        description: format!(
+                            "Cyber attack increased stress by {:.4}",
+                            stress_delta
+                        ),
                     });
                     effects.push(Effect {
                         layer: DomainLayer::Cyber,
@@ -442,7 +456,11 @@ impl SimulationEngine {
                 }
             }
             ActionType::InformationOp => {
-                if let Some(layer) = self.state.layers.get_mut(&DomainLayer::InformationCognitive) {
+                if let Some(layer) = self
+                    .state
+                    .layers
+                    .get_mut(&DomainLayer::InformationCognitive)
+                {
                     let stress_delta = intensity * 0.09;
                     layer.stress = (layer.stress + stress_delta).clamp(0.0, 1.0);
                     layer.friction = (layer.friction + intensity * 0.05).clamp(0.0, 1.0);
@@ -457,8 +475,10 @@ impl SimulationEngine {
                     });
                 }
                 // Also affect domestic political domain
-                if let Some(layer) =
-                    self.state.layers.get_mut(&DomainLayer::DomesticPoliticalFiscal)
+                if let Some(layer) = self
+                    .state
+                    .layers
+                    .get_mut(&DomainLayer::DomesticPoliticalFiscal)
                 {
                     let delta = intensity * 0.04;
                     layer.stress = (layer.stress + delta).clamp(0.0, 1.0);
@@ -466,16 +486,15 @@ impl SimulationEngine {
                         layer: DomainLayer::DomesticPoliticalFiscal,
                         field: "stress".into(),
                         delta,
-                        description: format!(
-                            "Info op spillover: domestic stress +{:.4}",
-                            delta
-                        ),
+                        description: format!("Info op spillover: domestic stress +{:.4}", delta),
                     });
                 }
             }
             ActionType::SanctionImpose => {
-                if let Some(layer) =
-                    self.state.layers.get_mut(&DomainLayer::GeoeconomicIndustrial)
+                if let Some(layer) = self
+                    .state
+                    .layers
+                    .get_mut(&DomainLayer::GeoeconomicIndustrial)
                 {
                     let stress_delta = intensity * 0.10;
                     layer.stress = (layer.stress + stress_delta).clamp(0.0, 1.0);
@@ -490,8 +509,10 @@ impl SimulationEngine {
                     });
                 }
                 // Sanctions also hurt own economy slightly
-                if let Some(layer) =
-                    self.state.layers.get_mut(&DomainLayer::DomesticPoliticalFiscal)
+                if let Some(layer) = self
+                    .state
+                    .layers
+                    .get_mut(&DomainLayer::DomesticPoliticalFiscal)
                 {
                     let delta = intensity * 0.02;
                     layer.stress = (layer.stress + delta).clamp(0.0, 1.0);
@@ -499,16 +520,15 @@ impl SimulationEngine {
                         layer: DomainLayer::DomesticPoliticalFiscal,
                         field: "stress".into(),
                         delta,
-                        description: format!(
-                            "Sanctions blowback: domestic stress +{:.4}",
-                            delta
-                        ),
+                        description: format!("Sanctions blowback: domestic stress +{:.4}", delta),
                     });
                 }
             }
             ActionType::SanctionRelief => {
-                if let Some(layer) =
-                    self.state.layers.get_mut(&DomainLayer::GeoeconomicIndustrial)
+                if let Some(layer) = self
+                    .state
+                    .layers
+                    .get_mut(&DomainLayer::GeoeconomicIndustrial)
                 {
                     let delta = intensity * 0.08;
                     layer.stress = (layer.stress - delta).clamp(0.0, 1.0);
@@ -580,7 +600,8 @@ impl SimulationEngine {
                 if let Some(layer) = self.state.layers.get_mut(&DomainLayer::SpacePnt) {
                     let stress_delta = intensity * 0.08;
                     layer.stress = (layer.stress + stress_delta).clamp(0.0, 1.0);
-                    layer.activity_level = (layer.activity_level + intensity * 0.15).clamp(0.0, 1.0);
+                    layer.activity_level =
+                        (layer.activity_level + intensity * 0.15).clamp(0.0, 1.0);
                     // But also increases own resilience in space
                     let res_delta = intensity * 0.04;
                     layer.resilience = (layer.resilience + res_delta).clamp(0.0, 1.0);
@@ -588,10 +609,7 @@ impl SimulationEngine {
                         layer: DomainLayer::SpacePnt,
                         field: "stress".into(),
                         delta: stress_delta,
-                        description: format!(
-                            "Space asset deployment: stress +{:.4}",
-                            stress_delta
-                        ),
+                        description: format!("Space asset deployment: stress +{:.4}", stress_delta),
                     });
                     effects.push(Effect {
                         layer: DomainLayer::SpacePnt,
@@ -605,15 +623,13 @@ impl SimulationEngine {
                 }
             }
             ActionType::DomesticPolicyShift => {
-                if let Some(layer) =
-                    self.state.layers.get_mut(&DomainLayer::DomesticPoliticalFiscal)
+                if let Some(layer) = self
+                    .state
+                    .layers
+                    .get_mut(&DomainLayer::DomesticPoliticalFiscal)
                 {
                     // Can either increase or decrease stress depending on direction
-                    let direction = action
-                        .parameters
-                        .get("direction")
-                        .copied()
-                        .unwrap_or(1.0); // positive = hawkish, negative = dovish
+                    let direction = action.parameters.get("direction").copied().unwrap_or(1.0); // positive = hawkish, negative = dovish
                     let delta = intensity * direction.signum() * 0.06;
                     layer.stress = (layer.stress + delta).clamp(0.0, 1.0);
                     let res_delta = intensity * 0.04;
@@ -631,10 +647,7 @@ impl SimulationEngine {
                         layer: DomainLayer::DomesticPoliticalFiscal,
                         field: "resilience".into(),
                         delta: res_delta,
-                        description: format!(
-                            "Policy shift: domestic resilience +{:.4}",
-                            res_delta
-                        ),
+                        description: format!("Policy shift: domestic resilience +{:.4}", res_delta),
                     });
                 }
             }
@@ -689,7 +702,8 @@ impl SimulationEngine {
         }
 
         // 2. Propagate stress through coupling matrix
-        self.coupling_matrix.propagate_stress(&mut self.state.layers);
+        self.coupling_matrix
+            .propagate_stress(&mut self.state.layers);
 
         // 3. Apply friction decay (stress naturally decays a bit each turn)
         for layer in self.state.layers.values_mut() {
@@ -875,7 +889,12 @@ impl SimulationEngine {
 
         let domain_stresses: Vec<(DomainLayer, f64)> = DomainLayer::ALL
             .iter()
-            .map(|d| (*d, self.state.layers.get(d).map(|l| l.stress).unwrap_or(0.0)))
+            .map(|d| {
+                (
+                    *d,
+                    self.state.layers.get(d).map(|l| l.stress).unwrap_or(0.0),
+                )
+            })
             .collect();
 
         let domain_resiliences: Vec<(DomainLayer, f64)> = DomainLayer::ALL
@@ -883,7 +902,11 @@ impl SimulationEngine {
             .map(|d| {
                 (
                     *d,
-                    self.state.layers.get(d).map(|l| l.resilience).unwrap_or(0.0),
+                    self.state
+                        .layers
+                        .get(d)
+                        .map(|l| l.resilience)
+                        .unwrap_or(0.0),
                 )
             })
             .collect();

--- a/services/sim-engine/src/events.rs
+++ b/services/sim-engine/src/events.rs
@@ -281,15 +281,27 @@ mod tests {
     #[test]
     fn test_default_events_count() {
         let events = default_stochastic_events();
-        assert!(events.len() >= 15, "Should have at least 15 events, got {}", events.len());
-        assert!(events.len() <= 25, "Should have at most 25 events, got {}", events.len());
+        assert!(
+            events.len() >= 15,
+            "Should have at least 15 events, got {}",
+            events.len()
+        );
+        assert!(
+            events.len() <= 25,
+            "Should have at most 25 events, got {}",
+            events.len()
+        );
     }
 
     #[test]
     fn test_events_have_valid_probabilities() {
         for ev in default_stochastic_events() {
-            assert!(ev.probability > 0.0 && ev.probability <= 1.0,
-                "Event '{}' has invalid probability: {}", ev.name, ev.probability);
+            assert!(
+                ev.probability > 0.0 && ev.probability <= 1.0,
+                "Event '{}' has invalid probability: {}",
+                ev.name,
+                ev.probability
+            );
         }
     }
 

--- a/services/sim-engine/src/main.rs
+++ b/services/sim-engine/src/main.rs
@@ -53,39 +53,28 @@ fn main() {
     }
 }
 
-fn handle_command(
-    engine: &mut Option<SimulationEngine>,
-    command: EngineCommand,
-) -> EngineResponse {
+fn handle_command(engine: &mut Option<SimulationEngine>, command: EngineCommand) -> EngineResponse {
     match command {
-        EngineCommand::NewGame { scenario_id, seed } => {
-            match get_scenario(&scenario_id) {
-                Some(scenario) => {
-                    let eng = SimulationEngine::new(scenario, seed);
-                    let state = eng.get_state().clone();
-                    *engine = Some(eng);
-                    info!("New game started: scenario={}, seed={}", scenario_id, seed);
-                    EngineResponse::ok(state)
-                }
-                None => EngineResponse::error(
-                    "SCENARIO_NOT_FOUND",
-                    format!("Scenario '{}' not found", scenario_id),
-                ),
+        EngineCommand::NewGame { scenario_id, seed } => match get_scenario(&scenario_id) {
+            Some(scenario) => {
+                let eng = SimulationEngine::new(scenario, seed);
+                let state = eng.get_state().clone();
+                *engine = Some(eng);
+                info!("New game started: scenario={}, seed={}", scenario_id, seed);
+                EngineResponse::ok(state)
             }
-        }
-        EngineCommand::GetState => {
-            with_engine(engine, |eng| EngineResponse::ok(eng.get_state()))
-        }
-        EngineCommand::GetRoleState { role_id } => {
-            with_engine(engine, |eng| {
-                EngineResponse::ok(eng.get_role_visible_state(&role_id))
-            })
-        }
-        EngineCommand::GetLegalActions { role_id } => {
-            with_engine(engine, |eng| {
-                EngineResponse::ok(eng.derive_legal_actions(&role_id))
-            })
-        }
+            None => EngineResponse::error(
+                "SCENARIO_NOT_FOUND",
+                format!("Scenario '{}' not found", scenario_id),
+            ),
+        },
+        EngineCommand::GetState => with_engine(engine, |eng| EngineResponse::ok(eng.get_state())),
+        EngineCommand::GetRoleState { role_id } => with_engine(engine, |eng| {
+            EngineResponse::ok(eng.get_role_visible_state(&role_id))
+        }),
+        EngineCommand::GetLegalActions { role_id } => with_engine(engine, |eng| {
+            EngineResponse::ok(eng.derive_legal_actions(&role_id))
+        }),
         EngineCommand::ValidateAction { action } => {
             with_engine(engine, |eng| match eng.validate_action(&action) {
                 Ok(()) => EngineResponse::ok("valid"),
@@ -98,18 +87,14 @@ fn handle_command(
                 Err(e) => EngineResponse::error("ACTION_ERROR", e.to_string()),
             })
         }
-        EngineCommand::AdvanceTurn => {
-            with_engine_mut(engine, |eng| {
-                let result = eng.advance_turn();
-                EngineResponse::ok(result)
-            })
-        }
-        EngineCommand::TakeSnapshot => {
-            with_engine_mut(engine, |eng| {
-                eng.take_snapshot();
-                EngineResponse::ok("snapshot_taken")
-            })
-        }
+        EngineCommand::AdvanceTurn => with_engine_mut(engine, |eng| {
+            let result = eng.advance_turn();
+            EngineResponse::ok(result)
+        }),
+        EngineCommand::TakeSnapshot => with_engine_mut(engine, |eng| {
+            eng.take_snapshot();
+            EngineResponse::ok("snapshot_taken")
+        }),
         EngineCommand::GetEventLog => {
             with_engine(engine, |eng| EngineResponse::ok(eng.get_event_log()))
         }
@@ -135,7 +120,10 @@ fn with_engine(
 ) -> EngineResponse {
     match engine {
         Some(eng) => f(eng),
-        None => EngineResponse::error("NOT_INITIALIZED", "No game in progress. Send NewGame first."),
+        None => EngineResponse::error(
+            "NOT_INITIALIZED",
+            "No game in progress. Send NewGame first.",
+        ),
     }
 }
 
@@ -145,7 +133,10 @@ fn with_engine_mut(
 ) -> EngineResponse {
     match engine {
         Some(eng) => f(eng),
-        None => EngineResponse::error("NOT_INITIALIZED", "No game in progress. Send NewGame first."),
+        None => EngineResponse::error(
+            "NOT_INITIALIZED",
+            "No game in progress. Send NewGame first.",
+        ),
     }
 }
 

--- a/services/sim-engine/src/phase.rs
+++ b/services/sim-engine/src/phase.rs
@@ -118,7 +118,7 @@ pub fn compute_order_parameter(layers: &HashMap<DomainLayer, LayerState>) -> f64
 /// Returns (enter_threshold, exit_threshold) for each phase.
 fn phase_thresholds(phase: Phase) -> (f64, f64) {
     match phase {
-        Phase::CompetitiveNormality => (0.0, 0.0),   // always possible to be here
+        Phase::CompetitiveNormality => (0.0, 0.0), // always possible to be here
         Phase::HybridCoercion => (0.15, 0.12),
         Phase::AcutePolycrisis => (0.30, 0.27),
         Phase::WarTransition => (0.50, 0.47),
@@ -195,7 +195,11 @@ mod tests {
             layers.insert(d, LayerState::new(0.9, 0.2, 0.1, 0.8));
         }
         let psi = compute_order_parameter(&layers);
-        assert!(psi > 0.5, "Psi should be high with high stress, got {}", psi);
+        assert!(
+            psi > 0.5,
+            "Psi should be high with high stress, got {}",
+            psi
+        );
     }
 
     #[test]
@@ -222,6 +226,10 @@ mod tests {
     fn test_default_weights_sum_to_one() {
         let w = default_domain_weights();
         let sum: f64 = w.values().sum();
-        assert!((sum - 1.0).abs() < 1e-10, "Weights should sum to 1.0, got {}", sum);
+        assert!(
+            (sum - 1.0).abs() < 1e-10,
+            "Weights should sum to 1.0, got {}",
+            sum
+        );
     }
 }

--- a/services/sim-engine/src/protocol.rs
+++ b/services/sim-engine/src/protocol.rs
@@ -5,29 +5,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "command", content = "data")]
 pub enum EngineCommand {
-    NewGame {
-        scenario_id: String,
-        seed: u64,
-    },
+    NewGame { scenario_id: String, seed: u64 },
     GetState,
-    GetRoleState {
-        role_id: String,
-    },
-    GetLegalActions {
-        role_id: String,
-    },
-    ValidateAction {
-        action: Action,
-    },
-    SubmitAction {
-        action: Action,
-    },
+    GetRoleState { role_id: String },
+    GetLegalActions { role_id: String },
+    ValidateAction { action: Action },
+    SubmitAction { action: Action },
     AdvanceTurn,
     TakeSnapshot,
     GetEventLog,
-    ReplayToTurn {
-        turn: u32,
-    },
+    ReplayToTurn { turn: u32 },
     GetMetrics,
     Shutdown,
 }
@@ -109,7 +96,12 @@ mod tests {
 
         for json in commands {
             let result: Result<EngineCommand, _> = serde_json::from_str(json);
-            assert!(result.is_ok(), "Failed to deserialize: {} -- error: {:?}", json, result.err());
+            assert!(
+                result.is_ok(),
+                "Failed to deserialize: {} -- error: {:?}",
+                json,
+                result.err()
+            );
         }
     }
 }

--- a/services/sim-engine/src/scenario.rs
+++ b/services/sim-engine/src/scenario.rs
@@ -207,10 +207,20 @@ mod tests {
         let actor_ids: Vec<Uuid> = scenario.actors.iter().map(|a| a.id).collect();
         for role in &scenario.roles {
             for aid in &role.controlled_actor_ids {
-                assert!(actor_ids.contains(aid), "Role {} references unknown actor {}", role.id, aid);
+                assert!(
+                    actor_ids.contains(aid),
+                    "Role {} references unknown actor {}",
+                    role.id,
+                    aid
+                );
             }
             for aid in &role.allied_actor_ids {
-                assert!(actor_ids.contains(aid), "Role {} references unknown allied actor {}", role.id, aid);
+                assert!(
+                    actor_ids.contains(aid),
+                    "Role {} references unknown allied actor {}",
+                    role.id,
+                    aid
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

- Remove unused Python imports flagged by ruff in `replay.py`, `narrative_service.py`, `narrator.py`, `test_engine_bridge.py`
- Run `cargo fmt` on sim-engine to fix formatting diffs
- Exclude `e2e/` from vitest config so Playwright specs aren't picked up by the wrong runner

## Test plan

- [ ] CI pipeline passes (API lint, engine format check, frontend vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)