### PR TITLE
fix: resolve clippy and mypy CI failures

### DIFF
--- a/apps/api/app/schemas/run.py
+++ b/apps/api/app/schemas/run.py
@@ -93,7 +93,8 @@ class RunRead(BaseModel):
                 d[field] = getattr(obj, field, None)
             # Map DB "running" to frontend "in_progress"
             status = getattr(obj, "status", None)
-            d["status"] = "in_progress" if str(status) == "running" or (hasattr(status, 'value') and status.value == "running") else str(status.value) if hasattr(status, 'value') else str(status)
+            status_str: str = str(getattr(status, 'value', status))
+            d["status"] = "in_progress" if status_str == "running" else status_str
             scenario = getattr(obj, "scenario", None)
             if scenario is not None:
                 d["scenario_name"] = getattr(scenario, "name", "")

--- a/apps/api/app/services/action_service.py
+++ b/apps/api/app/services/action_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
 import structlog
 from fastapi import HTTPException
@@ -88,7 +89,7 @@ class ActionService:
 
         # Build action_payload from individual fields if payload is empty
         if not data.action_payload:
-            payload = {}
+            payload: dict[str, Any] = {}
             if data.target_domain is not None:
                 payload["target_domain"] = data.target_domain
             if data.target_actor is not None:

--- a/services/sim-engine/src/engine.rs
+++ b/services/sim-engine/src/engine.rs
@@ -280,7 +280,7 @@ impl SimulationEngine {
 
         // Intensity validation
         let intensity = action.intensity();
-        if intensity < 0.0 || intensity > 1.0 {
+        if !(0.0..=1.0).contains(&intensity) {
             return Err(ActionError::InvalidParameter(
                 "intensity must be between 0.0 and 1.0".into(),
             ));


### PR DESCRIPTION
## Summary

- Use `RangeInclusive::contains` instead of manual comparison for intensity validation (clippy `manual_range_contains`)
- Simplify status mapping in `RunSummary` validator to avoid `.value` access on `None` (mypy `union-attr`)
- Add explicit `dict[str, Any]` type annotation for action payload dict (mypy `assignment`)

## Test plan

- [ ] CI pipeline passes (engine clippy, API mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)