### PR TITLE
fix: correct advance-turn test URL to match route

### DIFF
--- a/apps/api/app/tests/test_actions.py
+++ b/apps/api/app/tests/test_actions.py
@@ -86,7 +86,7 @@ async def test_submit_action_wrong_role(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_advance_turn(client: AsyncClient):
     run_id, _, _ = await _setup_running_run(client)
-    resp = await client.post(f"/api/v1/runs/{run_id}/advance-turn")
+    resp = await client.post(f"/api/v1/runs/{run_id}/advance")
     assert resp.status_code == 200
     data = resp.json()
     assert data["turn"] == 1

--- a/apps/api/app/tests/test_replay.py
+++ b/apps/api/app/tests/test_replay.py
@@ -19,7 +19,7 @@ async def _create_run_with_events(client: AsyncClient) -> str:
     run_id = resp.json()["id"]
 
     await client.post(f"/api/v1/runs/{run_id}/start")
-    await client.post(f"/api/v1/runs/{run_id}/advance-turn")
+    await client.post(f"/api/v1/runs/{run_id}/advance")
 
     return run_id
 


### PR DESCRIPTION
## Summary

- Tests were hitting `/advance-turn` but the route is `/advance`, causing 404 failures in CI
- `test_get_events` was a cascade failure (depends on advance working to generate events)

## Test plan

- [ ] All 34 API tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)