### PR TITLE
fix: set password_hash on AI user creation in quick_start

### DIFF
--- a/apps/api/app/services/run_manager.py
+++ b/apps/api/app/services/run_manager.py
@@ -531,6 +531,7 @@ class RunManager:
                 username="ai_commander",
                 display_name="AI Commander",
                 is_ai=True,
+                password_hash="!ai-service-account",
             )
             db.add(ai_user)
             await db.flush()


### PR DESCRIPTION
## Changes



## Testing

- API test suite: 32 passed (16 pre-existing failures unchanged)
- Verified `password_hash` is set on new AI user creation path

Closes #57