### PR TITLE
fix: add internal service key auth for AI agent API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ htmlcov/
 # Claude Code
 .claude/settings.local.json
 CLAUDE.local.md
+.last-run.json

--- a/apps/ai-agent/src/config.ts
+++ b/apps/ai-agent/src/config.ts
@@ -5,6 +5,8 @@ export const config = {
   apiBaseUrl: process.env.API_BASE_URL || "http://localhost:8000/api/v1",
   aiUserId:
     process.env.AI_USER_ID || "00000000-0000-0000-0002-000000000001",
+  internalServiceKey:
+    process.env.INTERNAL_SERVICE_KEY || "dev-internal-service-key",
   copilotApiKey: process.env.COPILOT_API_KEY || "",
   copilotModel: process.env.COPILOT_MODEL || "gpt-4",
   useMockAi: process.env.USE_MOCK_AI !== "false",

--- a/apps/ai-agent/src/services/auditLogger.ts
+++ b/apps/ai-agent/src/services/auditLogger.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import pino from "pino";
 import type { AiAuditEntry } from "../types/index.js";
+import { config } from "../config.js";
 
 const logger = pino({ level: "info" });
 
@@ -26,6 +27,10 @@ export class AuditLogger {
     try {
       await axios.post(`${this.apiBaseUrl}/ai/audit`, entry, {
         timeout: 5000,
+        headers: {
+          "X-Service-Key": config.internalServiceKey,
+          "X-User-Id": config.aiUserId,
+        },
       });
     } catch (err) {
       // Audit log persistence failure is non-fatal

--- a/apps/ai-agent/src/tools/endTurn.ts
+++ b/apps/ai-agent/src/tools/endTurn.ts
@@ -16,7 +16,7 @@ export async function endTurn(
     { roleId },
     {
       timeout: 10000,
-      headers: { "X-User-Id": config.aiUserId },
+      headers: { "X-Service-Key": config.internalServiceKey, "X-User-Id": config.aiUserId },
     }
   );
 

--- a/apps/ai-agent/src/tools/getRoleVisibleState.ts
+++ b/apps/ai-agent/src/tools/getRoleVisibleState.ts
@@ -11,7 +11,7 @@ export async function getRoleVisibleState(
     {
       params: { role_id: roleId },
       timeout: 10000,
-      headers: { "X-User-Id": config.aiUserId },
+      headers: { "X-Service-Key": config.internalServiceKey, "X-User-Id": config.aiUserId },
     }
   );
 

--- a/apps/ai-agent/src/tools/getTurnBrief.ts
+++ b/apps/ai-agent/src/tools/getTurnBrief.ts
@@ -16,7 +16,7 @@ export async function getTurnBrief(
       {
         params: { role_id: roleId },
         timeout: 10000,
-        headers: { "X-User-Id": config.aiUserId },
+        headers: { "X-Service-Key": config.internalServiceKey, "X-User-Id": config.aiUserId },
       }
     ),
     axios.get<LegalAction[]>(
@@ -24,7 +24,7 @@ export async function getTurnBrief(
       {
         params: { role_id: roleId },
         timeout: 10000,
-        headers: { "X-User-Id": config.aiUserId },
+        headers: { "X-Service-Key": config.internalServiceKey, "X-User-Id": config.aiUserId },
       }
     ),
   ]);

--- a/apps/ai-agent/src/tools/listLegalActions.ts
+++ b/apps/ai-agent/src/tools/listLegalActions.ts
@@ -11,7 +11,7 @@ export async function listLegalActions(
     {
       params: { role_id: roleId },
       timeout: 10000,
-      headers: { "X-User-Id": config.aiUserId },
+      headers: { "X-Service-Key": config.internalServiceKey, "X-User-Id": config.aiUserId },
     }
   );
 

--- a/apps/ai-agent/src/tools/submitAction.ts
+++ b/apps/ai-agent/src/tools/submitAction.ts
@@ -26,7 +26,7 @@ export async function submitAction(
     payload,
     {
       timeout: 10000,
-      headers: { "X-User-Id": config.aiUserId },
+      headers: { "X-Service-Key": config.internalServiceKey, "X-User-Id": config.aiUserId },
     }
   );
 

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -8,6 +8,7 @@ class Settings:
     database_url_sync: str
     engine_binary: str
     ai_agent_url: str
+    internal_service_key: str
     cors_origins: list[str]
     log_level: str
     jwt_secret_key: str
@@ -30,6 +31,9 @@ class Settings:
         )
         self.ai_agent_url = os.environ.get(
             "GREYZONE_AI_AGENT_URL", "http://localhost:3100"
+        )
+        self.internal_service_key = os.environ.get(
+            "GREYZONE_INTERNAL_SERVICE_KEY", "dev-internal-service-key"
         )
         cors_raw = os.environ.get(
             "GREYZONE_CORS_ORIGINS", "http://localhost:5173"

--- a/apps/api/app/middleware/auth.py
+++ b/apps/api/app/middleware/auth.py
@@ -31,6 +31,27 @@ async def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     db: AsyncSession = Depends(get_session),
 ) -> User:
+    # Service-to-service auth via internal service key + X-User-Id header
+    service_key = request.headers.get("X-Service-Key")
+    if service_key:
+        if service_key != settings.internal_service_key:
+            raise HTTPException(status_code=401, detail="Invalid service key")
+        user_id_header = request.headers.get("X-User-Id")
+        if not user_id_header:
+            raise HTTPException(
+                status_code=401, detail="X-User-Id header required with service key"
+            )
+        try:
+            user_id = uuid.UUID(user_id_header)
+        except ValueError as exc:
+            raise HTTPException(status_code=401, detail="Invalid X-User-Id") from exc
+        user = await db.get(User, user_id)
+        if user is None or not user.is_active:
+            raise HTTPException(status_code=401, detail="User not found")
+        request.state.user = user
+        return user
+
+    # Standard JWT Bearer auth
     if credentials is None:
         raise HTTPException(status_code=401, detail="Authentication required")
     payload = decode_access_token(credentials.credentials)


### PR DESCRIPTION
## Summary
AI agent tool calls to the API were failing with 401 because the API requires JWT Bearer tokens but the AI agent only sent `X-User-Id` headers.

## Changes
- **API config**: Added `internal_service_key` setting (env: `GREYZONE_INTERNAL_SERVICE_KEY`)
- **API auth middleware**: Added service key auth path — accepts `X-Service-Key` + `X-User-Id` headers for trusted service-to-service calls
- **AI agent config**: Added `internalServiceKey` config (env: `INTERNAL_SERVICE_KEY`)
- **AI agent tools**: All 6 tool files now send both auth headers
- **Audit logger**: Also sends auth headers for API persistence calls

## Testing
- API: 32 passed (16 pre-existing failures unchanged)
- AI agent: 42 passed

Closes #54