### PR TITLE
fix: correct AI agent submitAction payload to match API schema

### DIFF
--- a/apps/ai-agent/src/tools/submitAction.ts
+++ b/apps/ai-agent/src/tools/submitAction.ts
@@ -13,12 +13,15 @@ export async function submitAction(
   action: Record<string, unknown>
 ): Promise<SubmitActionResult> {
   const payload = {
-    roleId,
-    actionType: action.actionType,
-    targetDomain: action.targetDomain,
-    targetActorId: action.targetActorId,
+    user_id: config.aiUserId,
+    role_id: roleId,
+    action_type: action.actionType,
+    target_domain: action.targetDomain,
+    target_actor: action.targetActorId,
     intensity: action.intensity,
-    rationale: action.rationale,
+    action_payload: {
+      rationale: action.rationale,
+    },
   };
 
   const response = await axios.post<SubmitActionResult>(


### PR DESCRIPTION
## Summary
AI agent submitAction was sending camelCase fields but the API expects snake_case. Also missing required `user_id`.

## Changes
- Map camelCase → snake_case: `actionType` → `action_type`, `targetDomain` → `target_domain`, `targetActorId` → `target_actor`
- Add `user_id: config.aiUserId`
- Move `rationale` into `action_payload` dict

## Testing
- AI agent: 42 passed

Closes #55