### PR TITLE
fix: make endTurn a no-op to prevent recursive AI turn loop

### DIFF
--- a/apps/ai-agent/src/tools/endTurn.ts
+++ b/apps/ai-agent/src/tools/endTurn.ts
@@ -1,24 +1,19 @@
-import axios from "axios";
-import { config } from "../config.js";
-
 export interface EndTurnResult {
   success: boolean;
   nextTurn: number;
   message: string;
 }
 
+// No-op: the API controls turn advancement via run_manager.advance_turn().
+// The AI agent must NOT call advance-turn itself because that triggers
+// another AI auto-play cycle, creating an infinite recursive loop.
 export async function endTurn(
-  runId: string,
-  roleId: string
+  _runId: string,
+  _roleId: string
 ): Promise<EndTurnResult> {
-  const response = await axios.post<EndTurnResult>(
-    `${config.apiBaseUrl}/runs/${runId}/advance-turn`,
-    { roleId },
-    {
-      timeout: 10000,
-      headers: { "X-Service-Key": config.internalServiceKey, "X-User-Id": config.aiUserId },
-    }
-  );
-
-  return response.data;
+  return {
+    success: true,
+    nextTurn: -1,
+    message: "Turn signoff acknowledged (API manages advancement)",
+  };
 }


### PR DESCRIPTION
## Summary
The AI agent's `endTurn` tool called `POST /advance-turn`, which triggers AI auto-play inside `run_manager.advance_turn()`, creating an infinite recursive loop.

## Changes
- Made `endTurn` a synchronous no-op that returns success immediately
- Removed the axios call and unused imports
- The API controls turn sequencing — AI agent should not call advance-turn

## Testing
- AI agent: 42 passed

Closes #56