### PR TITLE
fix: add mappers for API response shape to AI agent types

### DIFF
--- a/apps/ai-agent/src/mappers/apiResponse.ts
+++ b/apps/ai-agent/src/mappers/apiResponse.ts
@@ -1,0 +1,111 @@
+/**
+ * Mappers to transform snake_case API responses into the camelCase types
+ * expected by the AI agent's internal logic.
+ *
+ * API (RunStateResponse):
+ *   { run_id, turn, phase, state: { order_parameter, layers: {Domain: LayerState}, actors, events, ... }, role_id }
+ *
+ * AI Agent (GameState):
+ *   { runId, turn, phase, orderParameter, domains: DomainState[], actors, events, metadata }
+ *
+ * API (LegalActionsResponse):
+ *   { run_id, role_id, turn, actions: [{ action_type, available_layers, actor_id, parameter_ranges, description }] }
+ *
+ * AI Agent (LegalAction):
+ *   { actionType, targetDomain, targetActorId, description, intensityRange, estimatedStressImpact }
+ */
+
+import type { GameState, DomainState, ActorState, GameEvent, GameMetadata } from "../types/state.js";
+import type { LegalAction } from "../types/index.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export function mapRunStateToGameState(apiResponse: any): GameState {
+  const state = apiResponse.state ?? apiResponse;
+
+  const layers: Record<string, any> = state.layers ?? {};
+  const domains: DomainState[] = Object.entries(layers).map(
+    ([domainName, layerState]: [string, any]) => ({
+      domain: domainName,
+      stress: layerState.stress ?? 0,
+      resilience: layerState.resilience ?? 0,
+      couplingStrength: layerState.variables ?? {},
+      recentEvents: [],
+    })
+  );
+
+  const actors: ActorState[] = (state.actors ?? []).map((a: any) => ({
+    actorId: String(a.id ?? a.actor_id ?? a.actorId ?? ""),
+    role: a.role ?? a.role_id ?? "",
+    resources: a.resources ?? 1.0,
+    morale: a.morale ?? 1.0,
+    visibility: a.visibility ?? {},
+  }));
+
+  const events: GameEvent[] = (state.events ?? []).map((e: any) => ({
+    eventId: String(e.id ?? e.event_id ?? e.eventId ?? ""),
+    turn: e.turn ?? 0,
+    domain: e.domain ?? e.domain_layer ?? "",
+    type: e.event_type ?? e.type ?? "",
+    description: e.description ?? "",
+    effects: e.effects ?? {},
+  }));
+
+  const metadata: GameMetadata = {
+    scenarioId: state.scenario_id ?? apiResponse.scenario_id ?? "",
+    maxTurns: state.max_turns ?? 30,
+    phaseThresholds: [],
+  };
+
+  return {
+    runId: String(apiResponse.run_id ?? ""),
+    turn: state.turn ?? apiResponse.turn ?? 0,
+    phase: String(state.phase ?? apiResponse.phase ?? "Competition"),
+    orderParameter: state.order_parameter ?? state.orderParameter ?? 0,
+    domains,
+    actors,
+    events,
+    metadata,
+  };
+}
+
+export function mapLegalActionsResponse(apiResponse: any): LegalAction[] {
+  const rawActions: any[] = apiResponse.actions ?? apiResponse ?? [];
+  const mapped: LegalAction[] = [];
+
+  for (const action of rawActions) {
+    const actionType = action.action_type ?? action.actionType ?? "";
+    const actorId = action.actor_id ?? action.actorId ?? undefined;
+    const description = action.description ?? "";
+    const paramRanges = action.parameter_ranges ?? action.parameterRanges ?? {};
+    const intensityRange: [number, number] = paramRanges.intensity ?? [0, 1];
+    const resourceCost = action.resource_cost ?? action.resourceCost ?? 0;
+
+    const availableLayers: string[] =
+      action.available_layers ?? action.availableLayers ?? [];
+
+    if (availableLayers.length === 0) {
+      mapped.push({
+        actionType,
+        targetDomain: "",
+        targetActorId: actorId ? String(actorId) : undefined,
+        description,
+        intensityRange,
+        estimatedStressImpact: resourceCost,
+      });
+    } else {
+      for (const layer of availableLayers) {
+        mapped.push({
+          actionType,
+          targetDomain: String(layer),
+          targetActorId: actorId ? String(actorId) : undefined,
+          description: `${description} [${layer}]`,
+          intensityRange,
+          estimatedStressImpact: resourceCost,
+        });
+      }
+    }
+  }
+
+  return mapped;
+}

--- a/apps/ai-agent/src/tools/getRoleVisibleState.ts
+++ b/apps/ai-agent/src/tools/getRoleVisibleState.ts
@@ -1,12 +1,13 @@
 import axios from "axios";
 import { config } from "../config.js";
 import type { GameState } from "../types/state.js";
+import { mapRunStateToGameState } from "../mappers/apiResponse.js";
 
 export async function getRoleVisibleState(
   runId: string,
   roleId: string
 ): Promise<GameState> {
-  const response = await axios.get<GameState>(
+  const response = await axios.get(
     `${config.apiBaseUrl}/runs/${runId}/state`,
     {
       params: { role_id: roleId },
@@ -15,5 +16,5 @@ export async function getRoleVisibleState(
     }
   );
 
-  return response.data;
+  return mapRunStateToGameState(response.data);
 }

--- a/apps/ai-agent/src/tools/getTurnBrief.ts
+++ b/apps/ai-agent/src/tools/getTurnBrief.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
 import { config } from "../config.js";
 import { StateCompiler } from "../services/stateCompiler.js";
-import type { TurnBrief, LegalAction } from "../types/index.js";
-import type { GameState } from "../types/state.js";
+import type { TurnBrief } from "../types/index.js";
+import { mapRunStateToGameState, mapLegalActionsResponse } from "../mappers/apiResponse.js";
 
 const stateCompiler = new StateCompiler();
 
@@ -11,7 +11,7 @@ export async function getTurnBrief(
   roleId: string
 ): Promise<TurnBrief> {
   const [stateResponse, actionsResponse] = await Promise.all([
-    axios.get<GameState>(
+    axios.get(
       `${config.apiBaseUrl}/runs/${runId}/state`,
       {
         params: { role_id: roleId },
@@ -19,7 +19,7 @@ export async function getTurnBrief(
         headers: { "X-Service-Key": config.internalServiceKey, "X-User-Id": config.aiUserId },
       }
     ),
-    axios.get<LegalAction[]>(
+    axios.get(
       `${config.apiBaseUrl}/runs/${runId}/legal-actions`,
       {
         params: { role_id: roleId },
@@ -29,8 +29,8 @@ export async function getTurnBrief(
     ),
   ]);
 
-  const currentState = stateResponse.data;
-  const legalActions = actionsResponse.data;
+  const currentState = mapRunStateToGameState(stateResponse.data);
+  const legalActions = mapLegalActionsResponse(actionsResponse.data);
 
   return stateCompiler.compileTurnBrief(runId, roleId, currentState, legalActions);
 }

--- a/apps/ai-agent/src/tools/listLegalActions.ts
+++ b/apps/ai-agent/src/tools/listLegalActions.ts
@@ -1,12 +1,13 @@
 import axios from "axios";
 import { config } from "../config.js";
 import type { LegalAction } from "../types/index.js";
+import { mapLegalActionsResponse } from "../mappers/apiResponse.js";
 
 export async function listLegalActions(
   runId: string,
   roleId: string
 ): Promise<LegalAction[]> {
-  const response = await axios.get<LegalAction[]>(
+  const response = await axios.get(
     `${config.apiBaseUrl}/runs/${runId}/legal-actions`,
     {
       params: { role_id: roleId },
@@ -15,5 +16,5 @@ export async function listLegalActions(
     }
   );
 
-  return response.data;
+  return mapLegalActionsResponse(response.data);
 }


### PR DESCRIPTION
## Summary
The API returns snake_case nested responses but the AI agent expects camelCase flat types. All state/action data was silently wrong.

## Changes
- Added `mappers/apiResponse.ts` with `mapRunStateToGameState()` and `mapLegalActionsResponse()`
- `mapRunStateToGameState`: Extracts nested `state`, converts `layers` HashMap → `domains[]` array, maps actors/events to camelCase
- `mapLegalActionsResponse`: Expands `ActionTemplate` (with `available_layers[]`) into individual `LegalAction` per domain, maps snake_case → camelCase
- Updated `getTurnBrief`, `getRoleVisibleState`, `listLegalActions` to use mappers

## Testing
- AI agent: 42 passed

Closes #58