### PR TITLE
chore: add user_id to structured log context for all authenticated requests

### DIFF
--- a/apps/api/app/middleware/auth.py
+++ b/apps/api/app/middleware/auth.py
@@ -2,6 +2,7 @@
 
 import uuid
 
+import structlog
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
@@ -49,6 +50,7 @@ async def get_current_user(
         if user is None or not user.is_active:
             raise HTTPException(status_code=401, detail="User not found")
         request.state.user = user
+        structlog.contextvars.bind_contextvars(user_id=str(user.id))
         return user
 
     # Standard JWT Bearer auth
@@ -63,4 +65,5 @@ async def get_current_user(
     if user is None or not user.is_active:
         raise HTTPException(status_code=401, detail="Invalid token")
     request.state.user = user
+    structlog.contextvars.bind_contextvars(user_id=str(user.id))
     return user

--- a/apps/api/app/middleware/logging.py
+++ b/apps/api/app/middleware/logging.py
@@ -27,6 +27,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
         except Exception as exc:  # Log unexpected errors with request context
             duration_ms = (time.monotonic() - start_time) * 1000
+            user_id = self._get_user_id(request)
             logger.exception(
                 "http_request_error",
                 method=request.method,
@@ -34,12 +35,14 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                 status_code=500,
                 duration_ms=round(duration_ms, 2),
                 correlation_id=correlation_id,
+                user_id=user_id,
                 error=str(exc),
             )
-            structlog.contextvars.unbind_contextvars("request_path", "request_method")
+            self._unbind()
             raise
 
         duration_ms = (time.monotonic() - start_time) * 1000
+        user_id = self._get_user_id(request)
         logger.info(
             "http_request",
             method=request.method,
@@ -47,6 +50,20 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             status_code=response.status_code,
             duration_ms=round(duration_ms, 2),
             correlation_id=correlation_id,
+            user_id=user_id,
         )
-        structlog.contextvars.unbind_contextvars("request_path", "request_method")
+        self._unbind()
         return response
+
+    @staticmethod
+    def _get_user_id(request: Request) -> str | None:
+        user = getattr(request.state, "user", None)
+        if user is not None:
+            return str(user.id)
+        return None
+
+    @staticmethod
+    def _unbind() -> None:
+        structlog.contextvars.unbind_contextvars(
+            "request_path", "request_method", "user_id"
+        )


### PR DESCRIPTION
## Summary
The backend already had structlog with JSON output, correlation ID middleware, and request logging. The missing piece was `user_id` in log entries for authenticated requests.

## Changes
- **auth middleware**: Binds `user_id` to structlog contextvars after successful authentication (both JWT and service key paths)
- **logging middleware**: Includes `user_id` in all `http_request` log entries; properly unbinds `user_id` context var after request

All items from #53 are now covered:
- ✅ Structured JSON logging (structlog + JSONRenderer)
- ✅ Timestamp (ISO format)
- ✅ Log level filtering
- ✅ Request ID (X-Correlation-ID middleware)
- ✅ User ID (when authenticated)
- ✅ Endpoint and duration

## Testing
- API: 32 passed (16 pre-existing failures unchanged)

Closes #53