### PR TITLE
feat: wire WebSocket broadcasts for turn events and state changes

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -55,6 +55,7 @@ logger = structlog.get_logger()
 engine_bridge = EngineBridge(settings.engine_binary)
 run_manager = RunManager(engine_bridge)
 ws_manager = ConnectionManager()
+run_manager.set_ws_manager(ws_manager)
 
 
 def _error_body(detail: object, request_id: str) -> dict:

--- a/apps/api/app/services/run_manager.py
+++ b/apps/api/app/services/run_manager.py
@@ -37,6 +37,20 @@ class RunManager:
         self.engine = engine
         self.narrative_service = NarrativeService()
         self._advance_locks: dict[uuid.UUID, asyncio.Lock] = {}
+        self._ws_manager: object | None = None
+
+    def set_ws_manager(self, ws_manager: object) -> None:
+        """Inject the ConnectionManager after construction to avoid circular imports."""
+        self._ws_manager = ws_manager
+
+    async def _broadcast(self, run_id: uuid.UUID, message: dict) -> None:
+        """Broadcast a WebSocket message to all clients in a run (best-effort)."""
+        if self._ws_manager is None:
+            return
+        try:
+            await self._ws_manager.broadcast_to_run(run_id, message)  # type: ignore[union-attr]
+        except Exception:
+            logger.warning("ws_broadcast_failed", run_id=str(run_id))
 
     def _get_run_lock(self, run_id: uuid.UUID) -> asyncio.Lock:
         """Return a per-run asyncio lock."""
@@ -465,6 +479,31 @@ class RunManager:
 
             turns_advanced_total.inc()
             await db.flush()
+
+            # Broadcast turn_advanced to all WebSocket clients
+            turn_message = {
+                "type": "turn_advanced",
+                "data": {
+                    "turn": new_turn,
+                    "phase": current_phase,
+                    "order_parameter": state.get("order_parameter", 0.0),
+                    "world_state": state,
+                    "events": events,
+                    "phase_changed": old_phase != current_phase,
+                },
+            }
+            await self._broadcast(run_id, turn_message)
+
+            # Broadcast phase_change if escalation phase shifted
+            if old_phase != current_phase:
+                await self._broadcast(run_id, {
+                    "type": "phase_change",
+                    "data": {
+                        "previous_phase": old_phase,
+                        "new_phase": current_phase,
+                        "turn": new_turn,
+                    },
+                })
 
             # Check for game over
             if result.get("game_over", False):

--- a/apps/api/app/tests/conftest.py
+++ b/apps/api/app/tests/conftest.py
@@ -117,6 +117,7 @@ async def client(
 
     run_manager = RunManager(mock_engine_bridge)
     ws_manager = ConnectionManager()
+    run_manager.set_ws_manager(ws_manager)
 
     runs_mod.set_services(mock_engine_bridge, run_manager, ws_manager)
     actions_mod.set_services(mock_engine_bridge, run_manager)
@@ -157,6 +158,7 @@ async def unauth_client(
 
     run_manager = RunManager(mock_engine_bridge)
     ws_manager = ConnectionManager()
+    run_manager.set_ws_manager(ws_manager)
 
     runs_mod.set_services(mock_engine_bridge, run_manager, ws_manager)
     actions_mod.set_services(mock_engine_bridge, run_manager)


### PR DESCRIPTION
## Changes

Connects the existing WebSocket infrastructure to the game lifecycle. Previously, `ConnectionManager.broadcast_to_run()` existed but was never called — the frontend was listening for messages that never arrived.

### What's Changed
- Added `set_ws_manager()` and `_broadcast()` helper to `RunManager`
- After `advance_turn()` completes: broadcasts `turn_advanced` message with `{turn, phase, order_parameter, world_state, events, phase_changed}`
- When escalation phase changes: broadcasts `phase_change` message with `{previous_phase, new_phase, turn}`
- Wired `ws_manager` into `RunManager` in `main.py` and test conftest

### Frontend Impact
The frontend hooks in `useWebSocket.ts` already listen for `turn_advanced` and `phase_change` — they now receive data:
- `turn_advanced` → updates world state, adds events to feed, records stress snapshot
- `phase_change` → creates a phase transition event in the feed

### Testing
- 32 pass / 16 fail — matches main baseline (no regressions)

Closes #70