### PR TITLE
feat: enrich event feed with narratives, AI actions, and intel

### DIFF
--- a/apps/web/src/components/simulation/EventFeed.tsx
+++ b/apps/web/src/components/simulation/EventFeed.tsx
@@ -15,6 +15,14 @@ function getEventClass(type: TurnEvent["type"]): string {
       return "event-item--phase_transition";
     case "coupling_effect":
       return "event-item--coupling_effect";
+    case "ai_action":
+      return "event-item--ai_action";
+    case "narrative":
+      return "event-item--narrative";
+    case "intel":
+      return "event-item--intel";
+    case "threat":
+      return "event-item--threat";
     default:
       return "event-item--turn";
   }
@@ -30,6 +38,14 @@ function getTypeBadge(type: TurnEvent["type"]): { label: string; className: stri
       return { label: "PHASE", className: "badge badge--red" };
     case "coupling_effect":
       return { label: "EFFECT", className: "badge badge--purple" };
+    case "ai_action":
+      return { label: "OPPONENT", className: "badge badge--orange" };
+    case "narrative":
+      return { label: "SITREP", className: "badge badge--teal" };
+    case "intel":
+      return { label: "INTEL", className: "badge badge--green" };
+    case "threat":
+      return { label: "THREAT", className: "badge badge--red" };
     default:
       return { label: "INFO", className: "badge badge--gray" };
   }

--- a/apps/web/src/hooks/useActions.ts
+++ b/apps/web/src/hooks/useActions.ts
@@ -59,6 +59,81 @@ export function useActions(runId: string | undefined) {
           result.world_state.layers as Record<DomainLayer, LayerState>
         );
       }
+
+      // Create synthetic events from narrative data
+      const syntheticEvents: TurnEvent[] = [];
+
+      if (result.narrative) {
+        syntheticEvents.push({
+          id: generateId(),
+          type: "narrative",
+          description: `📰 ${result.narrative.headline}`,
+          domain: null,
+          actor: null,
+          turn: result.turn,
+          visibility: "all",
+        });
+
+        if (result.narrative.threat_assessment) {
+          syntheticEvents.push({
+            id: generateId(),
+            type: "threat",
+            description: `⚠️ ${result.narrative.threat_assessment}`,
+            domain: null,
+            actor: null,
+            turn: result.turn,
+            visibility: "all",
+          });
+        }
+
+        if (result.narrative.intelligence_note) {
+          syntheticEvents.push({
+            id: generateId(),
+            type: "intel",
+            description: `🔍 ${result.narrative.intelligence_note}`,
+            domain: null,
+            actor: null,
+            turn: result.turn,
+            visibility: "all",
+          });
+        }
+
+        // Highlight significant domain changes
+        for (const highlight of result.narrative.domain_highlights) {
+          if (Math.abs(highlight.delta) >= 3) {
+            const arrow = highlight.direction === "rising" ? "📈" : highlight.direction === "falling" ? "📉" : "➡️";
+            syntheticEvents.push({
+              id: generateId(),
+              type: "stochastic",
+              description: `${arrow} ${highlight.label}: ${highlight.note}`,
+              domain: (highlight.domain as DomainLayer) || null,
+              actor: null,
+              turn: result.turn,
+              visibility: "all",
+            });
+          }
+        }
+      }
+
+      // Create events for AI actions
+      if (result.ai_actions?.length) {
+        for (const aiAction of result.ai_actions) {
+          syntheticEvents.push({
+            id: generateId(),
+            type: "ai_action",
+            description: `🤖 ${aiAction.description}`,
+            domain: (aiAction.layer as DomainLayer) || null,
+            actor: aiAction.role_id,
+            turn: result.turn,
+            visibility: "all",
+          });
+        }
+      }
+
+      if (syntheticEvents.length > 0) {
+        store().addEvents(syntheticEvents);
+      }
+
       if (runId) {
         queryClient.invalidateQueries({ queryKey: ["run", runId] });
         queryClient.invalidateQueries({ queryKey: ["legalActions", runId] });

--- a/apps/web/src/hooks/useWebSocket.ts
+++ b/apps/web/src/hooks/useWebSocket.ts
@@ -3,7 +3,7 @@ import { gameWebSocket } from "../api/websocket";
 import { useRunStore } from "../stores/runStore";
 import { useWebSocketStore } from "../stores/websocketStore";
 import { useAuthStore } from "../stores/authStore";
-import { TurnAdvancedMessage, PlayerJoinedMessage, AiMoveMessage } from "../types/websocket";
+import { TurnAdvancedMessage, PlayerJoinedMessage } from "../types/websocket";
 import { RunParticipant, WorldState, TurnEvent } from "../types/run";
 import { Phase } from "../types/phase";
 import { DomainLayer, LayerState } from "../types/domain";
@@ -136,8 +136,22 @@ export function useWebSocket(runId: string | undefined) {
 
     unsubs.push(
       gameWebSocket.on("ai_move", (data) => {
-        const msg = data as AiMoveMessage["data"];
-        rs().addAiMove(msg);
+        const msg = data as { turn: number; events: Array<{ description: string; layer: string; role_id: string }>; world_state: WorldState };
+        if (msg.world_state) {
+          rs().setWorldState(msg.world_state);
+        }
+        if (msg.events?.length) {
+          const aiEvents: TurnEvent[] = msg.events.map((evt, i) => ({
+            id: `ai-ws-${msg.turn}-${i}`,
+            type: "ai_action" as const,
+            description: `🤖 ${evt.description}`,
+            domain: (evt.layer as DomainLayer) || null,
+            actor: evt.role_id || null,
+            turn: msg.turn,
+            visibility: "all" as const,
+          }));
+          rs().addEvents(aiEvents);
+        }
       })
     );
 

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -509,6 +509,23 @@ input, select, textarea, button {
   border-left: 3px solid var(--text-muted);
 }
 
+.event-item--ai_action {
+  border-left: 3px solid #f97316;
+}
+
+.event-item--narrative {
+  border-left: 3px solid #14b8a6;
+}
+
+.event-item--intel {
+  border-left: 3px solid var(--accent-green);
+}
+
+.event-item--threat {
+  border-left: 3px solid var(--accent-red);
+  background: rgba(239, 68, 68, 0.05);
+}
+
 /* Action panel */
 .action-card {
   background: var(--bg-tertiary);
@@ -641,6 +658,16 @@ input[type="range"] {
 .badge--gray {
   background: rgba(161, 161, 170, 0.15);
   color: var(--text-secondary);
+}
+
+.badge--orange {
+  background: rgba(249, 115, 22, 0.15);
+  color: #f97316;
+}
+
+.badge--teal {
+  background: rgba(20, 184, 166, 0.15);
+  color: #14b8a6;
 }
 
 /* Player list */

--- a/apps/web/src/types/run.ts
+++ b/apps/web/src/types/run.ts
@@ -100,6 +100,29 @@ export interface LegalAction {
   side?: "blue" | "red";
 }
 
+export interface NarrativeData {
+  headline: string;
+  body: string;
+  domain_highlights: Array<{
+    domain: string;
+    label: string;
+    direction: "rising" | "falling" | "stable";
+    delta: number;
+    note: string;
+  }>;
+  threat_assessment: string;
+  intelligence_note: string | null;
+}
+
+export interface AiActionEvent {
+  type: string;
+  description: string;
+  layer: string;
+  role_id: string;
+  action_type: string;
+  intensity: number;
+}
+
 export interface TurnResult {
   turn: number;
   phase: Phase;
@@ -108,11 +131,13 @@ export interface TurnResult {
   events: TurnEvent[];
   phase_changed: boolean;
   previous_phase: Phase | null;
+  narrative: NarrativeData | null;
+  ai_actions: AiActionEvent[];
 }
 
 export interface TurnEvent {
   id: string;
-  type: "action" | "stochastic" | "phase_transition" | "coupling_effect";
+  type: "action" | "stochastic" | "phase_transition" | "coupling_effect" | "ai_action" | "narrative" | "intel" | "threat";
   description: string;
   domain: DomainLayer | null;
   actor: string | null;


### PR DESCRIPTION
## Changes

- **Narrative events in feed** — after each turn advance, the frontend creates synthetic events from the narrative data returned by the backend (#71):
  - `SITREP` — turn headline (teal badge)
  - `THREAT` — threat assessment warning (red badge)
  - `INTEL` — intelligence note (green badge)
  - Domain highlights for significant changes (delta ≥ 3)
- **AI opponent actions visible** — each AI action creates an `OPPONENT` event (orange badge) showing action type, target domain, and intensity
- **WebSocket ai_move handler updated** — now parses the new `{turn, events, world_state}` shape from #71 and creates proper TurnEvent entries
- **Type system extended** — `TurnResult` includes `narrative` and `ai_actions`; `TurnEvent.type` now includes `ai_action | narrative | intel | threat`
- **New CSS styles** — badge colors (orange, teal) and event item borders for all new types

## Result

The event feed is now populated every turn with 3-6+ events including situation reports, threat assessments, intelligence notes, domain change alerts, and opponent actions. Players can see what the AI is doing and understand the strategic context.

## Testing

```bash
cd apps/web && npx tsc --noEmit   # Clean
cd apps/web && npx vitest run     # 9 passed, 1 pre-existing failure (authStore localStorage mock)
```

Closes #73