### PR TITLE
feat: add scenario briefing panel with objectives and actors

### DIFF
--- a/apps/web/src/components/simulation/ScenarioBriefing.tsx
+++ b/apps/web/src/components/simulation/ScenarioBriefing.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getScenario } from "../../api/scenarios";
+import { ActorConfig } from "../../types/scenario";
+import Dialog from "../common/Dialog";
+
+interface ScenarioBriefingProps {
+  scenarioId: string;
+  scenarioName: string;
+  side: "blue" | "red";
+  currentTurn: number;
+}
+
+function getSideLabel(side: "blue" | "red"): string {
+  return side === "blue" ? "Blue (Defending)" : "Red (Aggressor)";
+}
+
+function getSideEmoji(actorSide: "blue" | "red" | "neutral"): string {
+  switch (actorSide) {
+    case "blue":
+      return "🔵";
+    case "red":
+      return "🔴";
+    case "neutral":
+      return "⚪";
+  }
+}
+
+function ActorCard({ actor }: { actor: ActorConfig }) {
+  return (
+    <div className={`briefing-actor briefing-actor--${actor.side}`}>
+      <div className="briefing-actor__header">
+        <span className="briefing-actor__emoji">{getSideEmoji(actor.side)}</span>
+        <span className="briefing-actor__name">{actor.name}</span>
+        <span className={`badge badge--${actor.side === "blue" ? "blue" : actor.side === "red" ? "red" : "gray"}`}>
+          {actor.side.toUpperCase()}
+        </span>
+      </div>
+      <p className="briefing-actor__desc">{actor.description}</p>
+      {actor.objectives.length > 0 && (
+        <ul className="briefing-actor__objectives">
+          {actor.objectives.map((obj, i) => (
+            <li key={i}>🎯 {obj}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function ScenarioBriefing({
+  scenarioId,
+  scenarioName,
+  side,
+  currentTurn,
+}: ScenarioBriefingProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { data: scenario } = useQuery({
+    queryKey: ["scenario", scenarioId],
+    queryFn: () => getScenario(scenarioId),
+    enabled: !!scenarioId,
+    staleTime: Infinity,
+  });
+
+  // Auto-open on turn 1
+  useEffect(() => {
+    if (currentTurn <= 1 && scenario) {
+      setIsOpen(true);
+    }
+  }, [currentTurn, scenario]);
+
+  const myActors = scenario?.actors.filter((a) => a.side === side) ?? [];
+  const opponentActors = scenario?.actors.filter((a) => a.side === (side === "blue" ? "red" : "blue")) ?? [];
+  const neutralActors = scenario?.actors.filter((a) => a.side === "neutral") ?? [];
+
+  return (
+    <>
+      <button
+        className="btn btn--sm briefing-trigger"
+        type="button"
+        onClick={() => setIsOpen(true)}
+        title="View scenario briefing"
+      >
+        📋 Briefing
+      </button>
+
+      <Dialog
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        title={`SCENARIO BRIEFING: ${scenarioName}`}
+        actions={
+          <button className="btn btn--primary btn--sm" onClick={() => setIsOpen(false)}>
+            Understood
+          </button>
+        }
+      >
+        <div className="briefing-content">
+          {scenario ? (
+            <>
+              <section className="briefing-section">
+                <h4 className="briefing-section__title">Situation Overview</h4>
+                <p className="briefing-section__body">{scenario.description}</p>
+              </section>
+
+              <section className="briefing-section">
+                <h4 className="briefing-section__title">
+                  Your Assignment — {getSideLabel(side)}
+                </h4>
+                {myActors.length > 0 ? (
+                  <div className="briefing-actors">
+                    {myActors.map((actor) => (
+                      <ActorCard key={actor.name} actor={actor} />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="briefing-section__body">No actor data available.</p>
+                )}
+              </section>
+
+              {opponentActors.length > 0 && (
+                <section className="briefing-section">
+                  <h4 className="briefing-section__title">Opposition Forces</h4>
+                  <div className="briefing-actors">
+                    {opponentActors.map((actor) => (
+                      <ActorCard key={actor.name} actor={actor} />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {neutralActors.length > 0 && (
+                <section className="briefing-section">
+                  <h4 className="briefing-section__title">Neutral Parties</h4>
+                  <div className="briefing-actors">
+                    {neutralActors.map((actor) => (
+                      <ActorCard key={actor.name} actor={actor} />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {scenario.author && (
+                <p className="briefing-meta">
+                  Scenario by {scenario.author}
+                </p>
+              )}
+            </>
+          ) : (
+            <p className="briefing-section__body">Loading scenario data...</p>
+          )}
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -15,6 +15,7 @@ import AiMovePanel from "../../components/ai/AiMovePanel";
 import BattlespaceCanvas from "./BattlespaceCanvas";
 import DomainStressChart from "./DomainStressChart";
 import AfterActionReport, { DomainDelta, computeDomainDeltas } from "./AfterActionReport";
+import ScenarioBriefing from "./ScenarioBriefing";
 import Dialog from "../common/Dialog";
 
 interface AarData {
@@ -63,6 +64,7 @@ export default function SimulationDashboard({
   const stressHistory = useRunStore((s) => s.stressHistory);
   const aiMoves = useRunStore((s) => s.aiMoves);
   const isAdvancingTurn = useRunStore((s) => s.isAdvancingTurn);
+  const run = useRunStore((s) => s.run);
 
   const { submitAction, isSubmitting, advanceTurn, isAdvancing, advanceError } =
     useActions(runId);
@@ -190,6 +192,14 @@ export default function SimulationDashboard({
             >
               ? Shortcuts
             </button>
+            {run?.scenario_id && (
+              <ScenarioBriefing
+                scenarioId={run.scenario_id}
+                scenarioName={run.scenario_name ?? run.name}
+                side={side}
+                currentTurn={currentTurn}
+              />
+            )}
           </div>
         </div>
         <div className="sim-top__right">

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -1933,3 +1933,102 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
   overflow: hidden;
   background: #111;
 }
+
+/* ── Scenario Briefing ──────────────────────────── */
+.briefing-trigger {
+  white-space: nowrap;
+}
+
+.briefing-content {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.briefing-section {
+  margin-bottom: 1.25rem;
+}
+
+.briefing-section__title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent-blue);
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.35rem;
+}
+
+.briefing-section__body {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.briefing-actors {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.briefing-actor {
+  background: var(--bg-tertiary);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  border-left: 3px solid var(--border);
+}
+
+.briefing-actor--blue {
+  border-left-color: var(--accent-blue);
+}
+
+.briefing-actor--red {
+  border-left-color: var(--accent-red);
+}
+
+.briefing-actor--neutral {
+  border-left-color: var(--text-muted);
+}
+
+.briefing-actor__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.briefing-actor__emoji {
+  font-size: 1rem;
+}
+
+.briefing-actor__name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.briefing-actor__desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.35rem;
+  line-height: 1.5;
+}
+
+.briefing-actor__objectives {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.82rem;
+}
+
+.briefing-actor__objectives li {
+  padding: 0.2rem 0;
+  color: var(--text-primary);
+}
+
+.briefing-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: right;
+  font-style: italic;
+}


### PR DESCRIPTION
## Changes

- **ScenarioBriefing component** — fetches full scenario data via `getScenario(id)` and displays:
  - Situation overview (scenario description)
  - Player assignment — your faction's actors with objectives
  - Opposition forces — enemy actors and their objectives
  - Neutral parties — independent actors and their role
- **Auto-opens on turn 1** — gives players immediate strategic context when the game starts
- **Accessible anytime** — `📋 Briefing` button in the top bar opens the dialog
- **Actor cards** — color-coded by faction (blue/red/neutral) with side badge, description, and 🎯 objectives list
- **CSS** — styling for briefing dialog, actor cards, objectives list, all using existing design tokens

## Result

Players now understand the scenario context, who they command, what their objectives are, and who they're up against — both at game start and on demand.

## Testing

```bash
cd apps/web && npx tsc --noEmit   # Clean
cd apps/web && npx vitest run     # 9 passed, 1 pre-existing failure
```

Closes #72