### PR TITLE
feat: add API rate limiting with slowapi

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -16,6 +16,9 @@ from app.config import settings
 from app.middleware.auth import get_current_user
 from app.middleware.correlation import CorrelationIdMiddleware
 from app.middleware.logging import LoggingMiddleware
+from app.middleware.rate_limit import limiter, rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from app.routers import (
     actions_router,
     ai_audit_router,
@@ -96,6 +99,7 @@ app = FastAPI(
 app.state.engine_bridge = engine_bridge
 app.state.run_manager = run_manager
 app.state.ws_manager = ws_manager
+app.state.limiter = limiter
 
 # Middleware (order matters: first added = outermost)
 app.add_middleware(
@@ -107,6 +111,9 @@ app.add_middleware(
 )
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(LoggingMiddleware)
+
+app.add_middleware(SlowAPIMiddleware)
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
 
 @app.exception_handler(StarletteHTTPException)

--- a/apps/api/app/middleware/rate_limit.py
+++ b/apps/api/app/middleware/rate_limit.py
@@ -1,0 +1,61 @@
+"""Rate limiting middleware using slowapi.
+
+Limits:
+- Auth endpoints: 5 req/min
+- Game creation: 10 req/min
+- General API: 60 req/min
+"""
+
+from __future__ import annotations
+
+import os
+
+import structlog
+from fastapi import Request, Response
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+from starlette.responses import JSONResponse
+
+logger = structlog.get_logger()
+
+
+def _key_func(request: Request) -> str:
+    """Extract client IP, preferring X-Forwarded-For behind nginx."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return get_remote_address(request)
+
+
+_enabled = os.environ.get("TESTING", "").lower() not in ("1", "true")
+
+limiter = Limiter(
+    key_func=_key_func,
+    default_limits=["60/minute"],
+    enabled=_enabled,
+)
+
+# Decorators for specific route limits
+auth_limit = limiter.limit("5/minute")
+create_limit = limiter.limit("10/minute")
+general_limit = limiter.limit("60/minute")
+
+
+async def rate_limit_exceeded_handler(
+    request: Request, exc: RateLimitExceeded
+) -> Response:
+    """Return 429 with Retry-After header."""
+    retry_after = getattr(exc, "retry_after", 60)
+    logger.warning(
+        "rate_limited",
+        path=request.url.path,
+        method=request.method,
+        client=_key_func(request),
+        limit=str(exc.detail),
+    )
+    return JSONResponse(
+        status_code=429,
+        content={"detail": f"Rate limit exceeded: {exc.detail}"},
+        headers={"Retry-After": str(retry_after)},
+    )

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -3,12 +3,13 @@
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from jose import JWTError, jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.db.session import get_session
+from app.middleware.rate_limit import auth_limit
 from app.schemas.auth import AuthResponse, LoginRequest, RefreshRequest, RegisterRequest
 from app.schemas.user import UserCreate, UserRead
 from app.services.user_service import UserService
@@ -43,8 +44,9 @@ def _decode_token(token: str, expected_type: str) -> dict:
 
 
 @router.post("/register", response_model=AuthResponse, status_code=201)
+@auth_limit
 async def register(
-    data: RegisterRequest, db: AsyncSession = Depends(get_session)
+    request: Request, data: RegisterRequest, db: AsyncSession = Depends(get_session)
 ) -> AuthResponse:
     user = await _user_service.create_user(
         db,
@@ -66,8 +68,9 @@ async def register(
 
 
 @router.post("/login", response_model=AuthResponse)
+@auth_limit
 async def login(
-    data: LoginRequest, db: AsyncSession = Depends(get_session)
+    request: Request, data: LoginRequest, db: AsyncSession = Depends(get_session)
 ) -> AuthResponse:
     user = await _user_service.get_user_by_username(db, data.username)
     password_hash = user.password_hash if user is not None else _DUMMY_PASSWORD_HASH
@@ -85,8 +88,9 @@ async def login(
 
 
 @router.post("/refresh", response_model=AuthResponse)
+@auth_limit
 async def refresh(
-    data: RefreshRequest, db: AsyncSession = Depends(get_session)
+    request: Request, data: RefreshRequest, db: AsyncSession = Depends(get_session)
 ) -> AuthResponse:
     payload = _decode_token(data.refresh_token, "refresh")
     try:
@@ -106,5 +110,6 @@ async def refresh(
 
 
 @router.post("/logout", status_code=204)
-async def logout() -> None:
+@auth_limit
+async def logout(request: Request) -> None:
     return None

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -2,10 +2,11 @@
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.middleware.auth import decode_access_token, get_current_user
+from app.middleware.rate_limit import create_limit
 from app.db.session import get_session
 from app.models.user import User
 from app.schemas.metrics import MetricsResponse
@@ -52,7 +53,9 @@ def get_ws_manager() -> ConnectionManager:
 
 
 @router.post("", response_model=RunRead, status_code=201)
+@create_limit
 async def create_run(
+    request: Request,
     data: RunCreate,
     db: AsyncSession = Depends(get_session),
     mgr: RunManager = Depends(get_run_manager),
@@ -72,7 +75,9 @@ async def list_runs(
 
 
 @router.post("/quick-start", response_model=RunRead, status_code=201)
+@create_limit
 async def quick_start(
+    request: Request,
     data: QuickStartRequest,
     db: AsyncSession = Depends(get_session),
     mgr: RunManager = Depends(get_run_manager),

--- a/apps/api/app/tests/conftest.py
+++ b/apps/api/app/tests/conftest.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import uuid
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock
+
+os.environ["TESTING"] = "true"
 
 import pytest
 import pytest_asyncio

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "passlib[bcrypt]>=1.7.4",
     "bcrypt<4.0.0",
     "python-jose[cryptography]>=3.3.0",
+    "slowapi>=0.1.9",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Changes

Adds tiered rate limiting to the FastAPI backend using slowapi to protect against brute-force attacks and API abuse.

### Rate Limits
| Tier | Limit | Endpoints |
|------|-------|-----------|
| Auth | 5/min | register, login, refresh, logout |
| Creation | 10/min | POST /runs, POST /runs/quick-start |
| General | 60/min | All other endpoints (default) |

### Implementation
- `app/middleware/rate_limit.py` — limiter instance, decorators, 429 handler
- IP extraction via X-Forwarded-For (nginx) with remote address fallback
- 429 responses include `Retry-After` header and structured log warnings
- Auto-disabled in test environment (`TESTING=true`) to avoid fixture rate limiting

### Files Changed
- `apps/api/app/middleware/rate_limit.py` — NEW: rate limiting middleware
- `apps/api/app/main.py` — Register SlowAPIMiddleware and exception handler
- `apps/api/app/routers/auth.py` — `@auth_limit` on all auth endpoints
- `apps/api/app/routers/runs.py` — `@create_limit` on run creation endpoints
- `apps/api/pyproject.toml` — Added `slowapi>=0.1.9` dependency
- `apps/api/app/tests/conftest.py` — Set `TESTING=true` env var

### Testing
- `pytest app/tests/ -q`: 32 passed, 16 pre-existing failures (unchanged from baseline)
- `ruff check`: All checks passed

Closes #52