### PR TITLE
test: add React component tests for simulation UI

### DIFF
--- a/apps/web/src/components/simulation/ActionPanel.test.tsx
+++ b/apps/web/src/components/simulation/ActionPanel.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import ActionPanel from "./ActionPanel";
+import { LegalAction } from "../../types/run";
+
+// ActionCard is complex — mock it to isolate ActionPanel logic
+vi.mock("./ActionCard", () => ({
+  __esModule: true,
+  default: ({ action }: { action: LegalAction }) => (
+    <div data-testid="action-card">{action.description}</div>
+  ),
+}));
+
+describe("ActionPanel", () => {
+  const makeLegalAction = (
+    overrides: Partial<LegalAction> = {}
+  ): LegalAction => ({
+    action_type: "diplomatic_engagement",
+    actor_id: "blue_state",
+    available_layers: ["diplomatic"],
+    description: "Initiate diplomatic talks",
+    parameter_ranges: { intensity: [0, 1] },
+    resource_cost: 5,
+    ...overrides,
+  });
+
+  const defaultProps = {
+    legalActions: [] as LegalAction[],
+    onSubmit: vi.fn(),
+    isSubmitting: false,
+    side: "blue" as const,
+  };
+
+  it("renders title", () => {
+    render(<ActionPanel {...defaultProps} />);
+    expect(screen.getByText("Available Actions")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no actions", () => {
+    render(<ActionPanel {...defaultProps} />);
+    expect(
+      screen.getByText("No actions available this turn.")
+    ).toBeInTheDocument();
+  });
+
+  it("does not show badge when no actions", () => {
+    const { container } = render(<ActionPanel {...defaultProps} />);
+    expect(container.querySelector(".badge")).not.toBeInTheDocument();
+  });
+
+  it("shows badge with count when actions exist", () => {
+    const actions = [makeLegalAction(), makeLegalAction({ action_type: "cyber_ops" })];
+    render(<ActionPanel {...defaultProps} legalActions={actions} />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("renders one ActionCard per legal action", () => {
+    const actions = [
+      makeLegalAction({ description: "Alpha strike" }),
+      makeLegalAction({ description: "Beta deploy" }),
+      makeLegalAction({ description: "Gamma patrol" }),
+    ];
+    render(<ActionPanel {...defaultProps} legalActions={actions} />);
+    expect(screen.getAllByTestId("action-card")).toHaveLength(3);
+    expect(screen.getByText("Alpha strike")).toBeInTheDocument();
+    expect(screen.getByText("Beta deploy")).toBeInTheDocument();
+    expect(screen.getByText("Gamma patrol")).toBeInTheDocument();
+  });
+
+  it("hides empty state when actions provided", () => {
+    render(
+      <ActionPanel {...defaultProps} legalActions={[makeLegalAction()]} />
+    );
+    expect(
+      screen.queryByText("No actions available this turn.")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/simulation/EventFeed.test.tsx
+++ b/apps/web/src/components/simulation/EventFeed.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import EventFeed from "./EventFeed";
+import { TurnEvent } from "../../types/run";
+import { DomainLayer } from "../../types/domain";
+
+describe("EventFeed", () => {
+  const makeEvent = (overrides: Partial<TurnEvent> = {}): TurnEvent => ({
+    id: "evt-1",
+    type: "action",
+    description: "Deployed forces to sector A",
+    domain: DomainLayer.Kinetic,
+    actor: "blue_commander",
+    turn: 1,
+    visibility: "all",
+    ...overrides,
+  });
+
+  it("renders empty state when no events", () => {
+    render(<EventFeed events={[]} />);
+    expect(screen.getByText("No events yet.")).toBeInTheDocument();
+  });
+
+  it("renders title", () => {
+    render(<EventFeed events={[]} />);
+    expect(screen.getByText("Event Feed")).toBeInTheDocument();
+  });
+
+  it("renders event description and turn", () => {
+    render(<EventFeed events={[makeEvent()]} />);
+    expect(screen.getByText("Deployed forces to sector A")).toBeInTheDocument();
+    expect(screen.getByText("T1")).toBeInTheDocument();
+  });
+
+  it("renders domain label for domain events", () => {
+    render(<EventFeed events={[makeEvent({ domain: DomainLayer.Cyber })]} />);
+    expect(screen.getByText("Cyber")).toBeInTheDocument();
+  });
+
+  it("omits domain label when domain is null", () => {
+    render(<EventFeed events={[makeEvent({ domain: null })]} />);
+    expect(screen.queryByText("Cyber")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["action", "ACTION"],
+    ["stochastic", "EVENT"],
+    ["phase_transition", "PHASE"],
+    ["coupling_effect", "EFFECT"],
+    ["ai_action", "OPPONENT"],
+    ["narrative", "SITREP"],
+    ["intel", "INTEL"],
+    ["threat", "THREAT"],
+  ] as const)("renders %s type as %s badge", (type, label) => {
+    render(<EventFeed events={[makeEvent({ type, id: `evt-${type}` })]} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("applies new animation class to first 3 events", () => {
+    const events = Array.from({ length: 5 }, (_, i) =>
+      makeEvent({ id: `evt-${i}`, turn: i })
+    );
+    const { container } = render(<EventFeed events={events} />);
+    const items = container.querySelectorAll(".event-item");
+    expect(items[0]).toHaveClass("event-item--new");
+    expect(items[2]).toHaveClass("event-item--new");
+    expect(items[3]).not.toHaveClass("event-item--new");
+  });
+
+  it("applies user-action class for executed actions", () => {
+    const { container } = render(
+      <EventFeed
+        events={[makeEvent({ description: "Executed cyber operation" })]}
+      />
+    );
+    const item = container.querySelector(".event-item--user-action");
+    expect(item).toBeInTheDocument();
+  });
+
+  it("does not apply user-action class for non-executed descriptions", () => {
+    const { container } = render(
+      <EventFeed events={[makeEvent({ description: "Forces deployed" })]} />
+    );
+    expect(
+      container.querySelector(".event-item--user-action")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders multiple events in order", () => {
+    const events = [
+      makeEvent({ id: "evt-1", description: "First event", turn: 1 }),
+      makeEvent({ id: "evt-2", description: "Second event", turn: 2 }),
+    ];
+    render(<EventFeed events={events} />);
+    expect(screen.getByText("First event")).toBeInTheDocument();
+    expect(screen.getByText("Second event")).toBeInTheDocument();
+    expect(screen.getByText("T1")).toBeInTheDocument();
+    expect(screen.getByText("T2")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/simulation/MetricsOverview.test.tsx
+++ b/apps/web/src/components/simulation/MetricsOverview.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import MetricsOverview from "./MetricsOverview";
+import { Phase } from "../../types/phase";
+import { WorldState } from "../../types/run";
+import { DomainLayer } from "../../types/domain";
+
+// InfoTooltip renders a toggle — mock for simplicity
+vi.mock("../common/InfoTooltip", () => ({
+  __esModule: true,
+  default: ({ label }: { label: string }) => <span>{label}</span>,
+}));
+
+describe("MetricsOverview", () => {
+  const baseProps = {
+    orderParameter: 0.42,
+    phase: Phase.HybridCoercion,
+    turn: 5,
+    eventCount: 12,
+    worldState: null as WorldState | null,
+    side: undefined as "blue" | "red" | undefined,
+  };
+
+  it("renders order parameter", () => {
+    render(<MetricsOverview {...baseProps} />);
+    expect(screen.getByText("Ψ = 0.420")).toBeInTheDocument();
+  });
+
+  it("renders phase label", () => {
+    render(<MetricsOverview {...baseProps} />);
+    expect(screen.getByText(/Hybrid Coercion/)).toBeInTheDocument();
+  });
+
+  it("renders turn number", () => {
+    render(<MetricsOverview {...baseProps} />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("renders event count", () => {
+    render(<MetricsOverview {...baseProps} />);
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  it("shows -- for dominant domain when no world state", () => {
+    render(<MetricsOverview {...baseProps} />);
+    expect(screen.getByText("--")).toBeInTheDocument();
+  });
+
+  it("computes dominant domain from world state", () => {
+    const worldState: WorldState = {
+      turn: 5,
+      phase: Phase.HybridCoercion,
+      order_parameter: 0.42,
+      coupling_matrix: {},
+      layers: {
+        [DomainLayer.Kinetic]: {
+          stress: 0.3,
+          resilience: 0.5,
+          friction: 0.1,
+          activity_level: 0,
+          variables: {},
+        },
+        [DomainLayer.Cyber]: {
+          stress: 0.8,
+          resilience: 0.4,
+          friction: 0.2,
+          activity_level: 0,
+          variables: {},
+        },
+      } as WorldState["layers"],
+    };
+    render(<MetricsOverview {...baseProps} worldState={worldState} />);
+    expect(screen.getByText("Cyber")).toBeInTheDocument();
+  });
+
+  it("computes average resilience from world state", () => {
+    const worldState: WorldState = {
+      turn: 5,
+      phase: Phase.HybridCoercion,
+      order_parameter: 0.42,
+      coupling_matrix: {},
+      layers: {
+        [DomainLayer.Kinetic]: {
+          stress: 0.2,
+          resilience: 0.6,
+          friction: 0.1,
+          activity_level: 0,
+          variables: {},
+        },
+        [DomainLayer.Cyber]: {
+          stress: 0.4,
+          resilience: 0.4,
+          friction: 0.2,
+          activity_level: 0,
+          variables: {},
+        },
+      } as WorldState["layers"],
+    };
+    render(<MetricsOverview {...baseProps} worldState={worldState} />);
+    // avg resilience = (0.6 + 0.4) / 2 = 0.5 → "50.0%"
+    expect(screen.getByText("50.0%")).toBeInTheDocument();
+  });
+
+  it("shows resources when side and actor data available", () => {
+    const worldState: WorldState = {
+      turn: 5,
+      phase: Phase.HybridCoercion,
+      order_parameter: 0.42,
+      coupling_matrix: {},
+      layers: {} as WorldState["layers"],
+      actors: [{ id: "blue_state", resources: 75.3 }],
+      roles: [{ id: "blue_commander", controlled_actor_ids: ["blue_state"] }],
+    };
+    render(
+      <MetricsOverview {...baseProps} worldState={worldState} side="blue" />
+    );
+    expect(screen.getByText("75 RP")).toBeInTheDocument();
+  });
+
+  it("hides resources card when no side provided", () => {
+    render(<MetricsOverview {...baseProps} />);
+    expect(screen.queryByText(/RP$/)).not.toBeInTheDocument();
+  });
+
+  it("renders tooltip labels", () => {
+    render(<MetricsOverview {...baseProps} />);
+    expect(
+      screen.getByText("What is the order parameter?")
+    ).toBeInTheDocument();
+    expect(screen.getByText("What do phases mean?")).toBeInTheDocument();
+    expect(screen.getByText("What is resilience?")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/simulation/ScenarioBriefing.test.tsx
+++ b/apps/web/src/components/simulation/ScenarioBriefing.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ScenarioBriefing from "./ScenarioBriefing";
+import { ScenarioRead } from "../../types/scenario";
+import { DomainLayer } from "../../types/domain";
+
+vi.mock("../../api/scenarios", () => ({
+  getScenario: vi.fn(),
+}));
+
+import { getScenario } from "../../api/scenarios";
+const mockGetScenario = vi.mocked(getScenario);
+
+function makeScenario(overrides: Partial<ScenarioRead> = {}): ScenarioRead {
+  return {
+    id: "scenario-1",
+    name: "Baltic Flashpoint",
+    description: "A crisis erupts in the Baltic region.",
+    author: "Greyzone Team",
+    domain_config: {} as ScenarioRead["domain_config"],
+    actors: [
+      {
+        name: "NATO Alliance",
+        side: "blue",
+        description: "Western defensive alliance",
+        objectives: ["Maintain stability"],
+      },
+      {
+        name: "Eastern Bloc",
+        side: "red",
+        description: "Revisionist state coalition",
+        objectives: ["Expand influence"],
+      },
+      {
+        name: "UN Observers",
+        side: "neutral",
+        description: "Neutral monitoring body",
+        objectives: [],
+      },
+    ],
+    coupling_matrix: {},
+    initial_phase: "CompetitiveNormality",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe("ScenarioBriefing", () => {
+  const defaultProps = {
+    scenarioId: "scenario-1",
+    scenarioName: "Baltic Flashpoint",
+    side: "blue" as const,
+    currentTurn: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders briefing trigger button", () => {
+    mockGetScenario.mockResolvedValue(makeScenario());
+    render(<ScenarioBriefing {...defaultProps} />, { wrapper });
+    expect(screen.getByTitle("View scenario briefing")).toBeInTheDocument();
+    expect(screen.getByText(/Briefing/)).toBeInTheDocument();
+  });
+
+  it("auto-opens dialog on turn 1 when scenario loads", async () => {
+    mockGetScenario.mockResolvedValue(makeScenario());
+    render(<ScenarioBriefing {...defaultProps} currentTurn={1} />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("SCENARIO BRIEFING: Baltic Flashpoint")
+    ).toBeInTheDocument();
+  });
+
+  it("shows loading state before data arrives", () => {
+    mockGetScenario.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<ScenarioBriefing {...defaultProps} />, { wrapper });
+    fireEvent.click(screen.getByTitle("View scenario briefing"));
+    expect(
+      screen.getByText("Loading scenario data...")
+    ).toBeInTheDocument();
+  });
+
+  it("shows scenario description when loaded", async () => {
+    mockGetScenario.mockResolvedValue(makeScenario());
+    render(<ScenarioBriefing {...defaultProps} />, { wrapper });
+    await waitFor(() => {
+      expect(
+        screen.getByText("A crisis erupts in the Baltic region.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows player actors under Your Assignment", async () => {
+    mockGetScenario.mockResolvedValue(makeScenario());
+    render(<ScenarioBriefing {...defaultProps} side="blue" />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByText("NATO Alliance")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Your Assignment — Blue \(Defending\)/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows opponent actors under Opposition Forces", async () => {
+    mockGetScenario.mockResolvedValue(makeScenario());
+    render(<ScenarioBriefing {...defaultProps} side="blue" />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByText("Eastern Bloc")).toBeInTheDocument();
+      expect(screen.getByText("Opposition Forces")).toBeInTheDocument();
+    });
+  });
+
+  it("shows neutral actors section", async () => {
+    mockGetScenario.mockResolvedValue(makeScenario());
+    render(<ScenarioBriefing {...defaultProps} />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByText("UN Observers")).toBeInTheDocument();
+      expect(screen.getByText("Neutral Parties")).toBeInTheDocument();
+    });
+  });
+
+  it("renders actor objectives", async () => {
+    mockGetScenario.mockResolvedValue(makeScenario());
+    render(<ScenarioBriefing {...defaultProps} />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByText(/Maintain stability/)).toBeInTheDocument();
+      expect(screen.getByText(/Expand influence/)).toBeInTheDocument();
+    });
+  });
+
+  it("closes dialog on Understood button click", async () => {
+    mockGetScenario.mockResolvedValue(makeScenario());
+    render(<ScenarioBriefing {...defaultProps} />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Understood"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows author if present", async () => {
+    mockGetScenario.mockResolvedValue(makeScenario({ author: "John Doe" }));
+    render(<ScenarioBriefing {...defaultProps} />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByText(/John Doe/)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/simulation/TurnControls.test.tsx
+++ b/apps/web/src/components/simulation/TurnControls.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import TurnControls from "./TurnControls";
+
+describe("TurnControls", () => {
+  const defaultProps = {
+    turn: 3,
+    isAdvancing: false,
+    onAdvanceTurn: vi.fn(),
+    isObserver: false,
+  };
+
+  it("displays the current turn number", () => {
+    render(<TurnControls {...defaultProps} />);
+    expect(screen.getByText("Turn 3")).toBeInTheDocument();
+  });
+
+  it("renders End Turn button for players", () => {
+    render(<TurnControls {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: "End Turn" })
+    ).toBeInTheDocument();
+  });
+
+  it("hides button for observers", () => {
+    render(<TurnControls {...defaultProps} isObserver />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("disables button when advancing", () => {
+    render(<TurnControls {...defaultProps} isAdvancing />);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("shows Advancing text when advancing", () => {
+    render(<TurnControls {...defaultProps} isAdvancing />);
+    expect(
+      screen.getByRole("button", { name: "Advancing..." })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onAdvanceTurn when button clicked", () => {
+    const fn = vi.fn();
+    render(<TurnControls {...defaultProps} onAdvanceTurn={fn} />);
+    fireEvent.click(screen.getByRole("button", { name: "End Turn" }));
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onAdvanceTurn when disabled", () => {
+    const fn = vi.fn();
+    render(
+      <TurnControls {...defaultProps} onAdvanceTurn={fn} isAdvancing />
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(fn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Changes

Add comprehensive tests for 5 core simulation components, bringing frontend test coverage for the simulation UI to a solid baseline.

### New test files:
- **EventFeed.test.tsx** (11 tests): badge type mapping for all 8 event types, empty state, domain labels, new animation class on first 3 items, user-action class for executed actions
- **TurnControls.test.tsx** (7 tests): turn number display, End Turn button, observer role hides button, advancing disables button with text change, click handler
- **ActionPanel.test.tsx** (6 tests): title, empty state message, badge with count, ActionCard rendering per legal action (ActionCard mocked)
- **MetricsOverview.test.tsx** (10 tests): order parameter formatting, phase label, turn/event counts, dominant domain computation from world state, avg resilience calculation, conditional resources card, InfoTooltip labels
- **ScenarioBriefing.test.tsx** (9 tests): React Query mock with QueryClientProvider, auto-open on turn 1, loading state, scenario description, actor filtering by side, opponent/neutral sections, objectives, dialog close, author display

### Testing
```
npx vitest run  # 90 passed, 2 pre-existing failures (authStore localStorage mock)
```

Closes #48