### PR TITLE
fix: read events_fired key from engine and convert to frontend format

### DIFF
--- a/apps/api/app/services/run_manager.py
+++ b/apps/api/app/services/run_manager.py
@@ -372,7 +372,32 @@ class RunManager:
 
             new_turn = result.get("turn", state.get("turn", run.current_turn + 1))
             current_phase = result.get("phase", state.get("phase", run.current_phase))
-            events = result.get("events", [])
+
+            # Engine serializes stochastic events as "events_fired"
+            raw_events = result.get("events_fired", [])
+            events: list[dict] = []
+            for raw in raw_events:
+                events.append({
+                    "type": "stochastic",
+                    "description": raw.get("description", ""),
+                    "domain": raw.get("affected_layer", ""),
+                    "name": raw.get("name", ""),
+                    "stress_delta": raw.get("stress_delta", 0),
+                    "resilience_delta": raw.get("resilience_delta", 0),
+                    "visibility": raw.get("visibility", "Public"),
+                })
+
+            # Add phase transition event if phase changed
+            if current_phase != old_phase:
+                events.append({
+                    "type": "phase_transition",
+                    "description": (
+                        f"Escalation phase shifted from {old_phase} to {current_phase}"
+                    ),
+                    "domain": "",
+                    "previous_phase": old_phase,
+                    "new_phase": current_phase,
+                })
 
             # Update run in database
             run.current_turn = new_turn
@@ -449,7 +474,7 @@ class RunManager:
                             {
                                 "event_type": evt.get("type", "unknown"),
                                 "description": evt.get("description", ""),
-                                "layer": evt.get("layer", ""),
+                                "layer": evt.get("domain", ""),
                             }
                             for evt in events
                         ],


### PR DESCRIPTION
## Changes

The Rust engine's `TurnResult` serializes stochastic events as `events_fired` but `run_manager.py` was reading `events` — which was always an empty list. This caused:

- **Event feed always empty** — no stochastic events ever reached the frontend
- **No RunEvent records persisted** to the database
- **Narrative service received empty events**, producing generic text every turn

### Fix
- Read `result.get('events_fired', [])` instead of `result.get('events', [])`
- Convert engine `StochasticEvent` format `{name, affected_layer, stress_delta, ...}` to frontend `TurnEvent` format `{type, description, domain, ...}`
- Synthesize `phase_transition` events when escalation phase changes
- Map `domain` field correctly for narrative service

## Testing
- `ruff check app/services/run_manager.py` — all checks passed
- `pytest app/tests/ -q` — 54 passed, 16 failed (all pre-existing)

## Files
- `apps/api/app/services/run_manager.py`

Closes #83