### PR TITLE
fix: store world state in snapshots, fixing narrative generation on turn 2+

### DIFF
--- a/apps/api/app/services/run_manager.py
+++ b/apps/api/app/services/run_manager.py
@@ -415,13 +415,13 @@ class RunManager:
                 db.add(event)
 
             snapshot_taken = False
-            # Take and persist snapshot
+            # Take engine-side snapshot and persist world state
             try:
-                snapshot_data = await self.engine.take_snapshot(run_id)
+                await self.engine.take_snapshot(run_id)
                 snapshot = RunSnapshot(
                     run_id=run_id,
                     turn=new_turn,
-                    state=snapshot_data,
+                    state=state,  # actual world state dict, not engine ack string
                 )
                 db.add(snapshot)
                 snapshot_taken = True

--- a/services/sim-engine/src/engine.rs
+++ b/services/sim-engine/src/engine.rs
@@ -765,13 +765,14 @@ impl SimulationEngine {
     }
 
     /// Take a snapshot of the current state.
-    pub fn take_snapshot(&mut self) {
+    pub fn take_snapshot(&mut self) -> &WorldState {
         let snapshot_event = Event::SnapshotTaken {
             turn: self.state.turn,
         };
         self.state.events.push(snapshot_event.clone());
         self.event_log.push(snapshot_event);
         self.snapshots.push((self.state.turn, self.state.clone()));
+        &self.state
     }
 
     /// Get the event log.

--- a/services/sim-engine/src/main.rs
+++ b/services/sim-engine/src/main.rs
@@ -92,8 +92,8 @@ fn handle_command(engine: &mut Option<SimulationEngine>, command: EngineCommand)
             EngineResponse::ok(result)
         }),
         EngineCommand::TakeSnapshot => with_engine_mut(engine, |eng| {
-            eng.take_snapshot();
-            EngineResponse::ok("snapshot_taken")
+            let state = eng.take_snapshot();
+            EngineResponse::ok(state)
         }),
         EngineCommand::GetEventLog => {
             with_engine(engine, |eng| EngineResponse::ok(eng.get_event_log()))


### PR DESCRIPTION
## Bug

The engine's `TakeSnapshot` command returned the string `"snapshot_taken"` via `EngineResponse::ok("snapshot_taken")`. This was stored as `RunSnapshot.state`.

On turn 2+, narrative generation tried:
```python
prev_domain_states = prev_state.get("layers", {})  # AttributeError!
```

This crashed silently inside a try/except, so narrative generation failed for all turns after the first.

## Changes
- **API**: Store actual world state dict (already fetched via `get_state()`) as snapshot data
- **Engine**: `take_snapshot()` now returns `&WorldState` instead of `()`
- **Engine main.rs**: TakeSnapshot handler returns state data in response

## Testing
- `cargo test` — 58 tests passed
- `cargo clippy -- -D warnings` — clean
- `ruff check app/services/run_manager.py` — clean

## Files
- `apps/api/app/services/run_manager.py`
- `services/sim-engine/src/engine.rs`
- `services/sim-engine/src/main.rs`

Closes #85