### PR TITLE
feat: make sidebar navigation collapsible

### DIFF
--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -1,11 +1,22 @@
 import { Outlet } from "react-router-dom";
+import { useState, useEffect } from "react";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
 
+const SIDEBAR_KEY = "greyzone-sidebar-collapsed";
+
 export default function AppLayout() {
+  const [collapsed, setCollapsed] = useState(() => {
+    return localStorage.getItem(SIDEBAR_KEY) === "true";
+  });
+
+  useEffect(() => {
+    localStorage.setItem(SIDEBAR_KEY, String(collapsed));
+  }, [collapsed]);
+
   return (
-    <div className="app-layout">
-      <Sidebar />
+    <div className={`app-layout${collapsed ? " sidebar-collapsed" : ""}`}>
+      <Sidebar collapsed={collapsed} onToggle={() => setCollapsed((v) => !v)} />
       <div className="app-main">
         <Header />
         <main className="app-content">

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -2,7 +2,12 @@ import { NavLink } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { listRuns } from "../../api/runs";
 
-export default function Sidebar() {
+interface SidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const { data: runs } = useQuery({
     queryKey: ["runs"],
     queryFn: listRuns,
@@ -14,116 +19,127 @@ export default function Sidebar() {
   );
 
   return (
-    <aside className="app-sidebar">
-      <div className="sidebar-section-title">Navigation</div>
-      <ul className="sidebar-nav">
-        <li className="sidebar-nav__item">
-          <NavLink
-            to="/"
-            className={({ isActive }) =>
-              `sidebar-nav__link${isActive ? " active" : ""}`
-            }
-            end
-          >
-            Home
-          </NavLink>
-        </li>
-        <li className="sidebar-nav__item">
-          <NavLink
-            to="/scenarios"
-            className={({ isActive }) =>
-              `sidebar-nav__link${isActive ? " active" : ""}`
-            }
-          >
-            Scenarios
-          </NavLink>
-        </li>
-        <li className="sidebar-nav__item">
-          <NavLink
-            to="/runs/new"
-            className={({ isActive }) =>
-              `sidebar-nav__link${isActive ? " active" : ""}`
-            }
-          >
-            New Run
-          </NavLink>
-        </li>
-        <li className="sidebar-nav__item">
-          <NavLink
-            to="/tutorial"
-            className={({ isActive }) =>
-              `sidebar-nav__link${isActive ? " active" : ""}`
-            }
-          >
-            Tutorial
-          </NavLink>
-        </li>
-      </ul>
+    <aside className={`app-sidebar${collapsed ? " app-sidebar--collapsed" : ""}`}>
+      <button
+        className="sidebar-toggle"
+        onClick={onToggle}
+        aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          {collapsed ? (
+            <path d="M6 3l5 5-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          ) : (
+            <path d="M10 3L5 8l5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          )}
+        </svg>
+      </button>
 
-      <div className="sidebar-section-title">Docs & Help</div>
-      <ul className="sidebar-nav">
-        <li className="sidebar-nav__item">
-          <NavLink
-            to="/help"
-            className={({ isActive }) =>
-              `sidebar-nav__link${isActive ? " active" : ""}`
-            }
-          >
-            Help & FAQ
-          </NavLink>
-        </li>
-        <li className="sidebar-nav__item">
-          <a
-            href="https://github.com/idealase/greyzone/blob/main/docs/simulation-spec.md"
-            className="sidebar-nav__link"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Simulation Spec ↗
-          </a>
-        </li>
-        <li className="sidebar-nav__item">
-          <a
-            href="https://github.com/idealase/greyzone/blob/main/docs/product-spec.md"
-            className="sidebar-nav__link"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Product Spec ↗
-          </a>
-        </li>
-      </ul>
+      <div className="sidebar-scroll">
+        <div className="sidebar-section-title">{collapsed ? "" : "Navigation"}</div>
+        <ul className="sidebar-nav">
+          <SidebarLink to="/" label="Home" icon="⌂" collapsed={collapsed} end />
+          <SidebarLink to="/scenarios" label="Scenarios" icon="◈" collapsed={collapsed} />
+          <SidebarLink to="/runs/new" label="New Run" icon="+" collapsed={collapsed} />
+          <SidebarLink to="/tutorial" label="Tutorial" icon="?" collapsed={collapsed} />
+        </ul>
 
-      {activeRuns && activeRuns.length > 0 && (
-        <>
-          <div className="sidebar-section-title">Active Runs</div>
-          <ul className="sidebar-nav">
-            {activeRuns.map((run) => (
-              <li key={run.id} className="sidebar-nav__item">
-                <NavLink
-                  to={
-                    run.status === "lobby"
-                      ? `/runs/${run.id}/lobby`
-                      : `/runs/${run.id}`
-                  }
-                  className={({ isActive }) =>
-                    `sidebar-nav__link${isActive ? " active" : ""}`
-                  }
-                >
-                  <span>{run.name}</span>
-                  <span
-                    className={`badge badge--${
-                      run.status === "lobby" ? "yellow" : "green"
-                    }`}
+        <div className="sidebar-section-title">{collapsed ? "" : "Docs & Help"}</div>
+        <ul className="sidebar-nav">
+          <SidebarLink to="/help" label="Help & FAQ" icon="📖" collapsed={collapsed} />
+          <li className="sidebar-nav__item">
+            <a
+              href="https://github.com/idealase/greyzone/blob/main/docs/simulation-spec.md"
+              className="sidebar-nav__link"
+              target="_blank"
+              rel="noreferrer"
+              title={collapsed ? "Simulation Spec" : undefined}
+            >
+              <span className="sidebar-icon">📄</span>
+              {!collapsed && <span>Simulation Spec ↗</span>}
+            </a>
+          </li>
+          <li className="sidebar-nav__item">
+            <a
+              href="https://github.com/idealase/greyzone/blob/main/docs/product-spec.md"
+              className="sidebar-nav__link"
+              target="_blank"
+              rel="noreferrer"
+              title={collapsed ? "Product Spec" : undefined}
+            >
+              <span className="sidebar-icon">📋</span>
+              {!collapsed && <span>Product Spec ↗</span>}
+            </a>
+          </li>
+        </ul>
+
+        {activeRuns && activeRuns.length > 0 && (
+          <>
+            <div className="sidebar-section-title">{collapsed ? "" : "Active Runs"}</div>
+            <ul className="sidebar-nav">
+              {activeRuns.map((run) => (
+                <li key={run.id} className="sidebar-nav__item">
+                  <NavLink
+                    to={
+                      run.status === "lobby"
+                        ? `/runs/${run.id}/lobby`
+                        : `/runs/${run.id}`
+                    }
+                    className={({ isActive }) =>
+                      `sidebar-nav__link${isActive ? " active" : ""}`
+                    }
+                    title={collapsed ? run.name : undefined}
                   >
-                    {run.status === "lobby" ? "Lobby" : `T${run.current_turn}`}
-                  </span>
-                </NavLink>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+                    <span className="sidebar-icon">▶</span>
+                    {!collapsed && (
+                      <>
+                        <span>{run.name}</span>
+                        <span
+                          className={`badge badge--${
+                            run.status === "lobby" ? "yellow" : "green"
+                          }`}
+                        >
+                          {run.status === "lobby" ? "Lobby" : `T${run.current_turn}`}
+                        </span>
+                      </>
+                    )}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
     </aside>
+  );
+}
+
+function SidebarLink({
+  to,
+  label,
+  icon,
+  collapsed,
+  end,
+}: {
+  to: string;
+  label: string;
+  icon: string;
+  collapsed: boolean;
+  end?: boolean;
+}) {
+  return (
+    <li className="sidebar-nav__item">
+      <NavLink
+        to={to}
+        className={({ isActive }) =>
+          `sidebar-nav__link${isActive ? " active" : ""}`
+        }
+        end={end}
+        title={collapsed ? label : undefined}
+      >
+        <span className="sidebar-icon">{icon}</span>
+        {!collapsed && <span>{label}</span>}
+      </NavLink>
+    </li>
   );
 }

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -65,10 +65,53 @@ input, select, textarea, button {
   width: 220px;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border);
-  padding: 1rem 0;
+  padding: 0;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
+  transition: width 0.2s ease;
+  overflow: hidden;
+  position: relative;
+}
+
+.app-sidebar--collapsed {
+  width: 48px;
+}
+
+.sidebar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 40px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.sidebar-toggle:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.sidebar-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0.5rem 0;
+}
+
+.sidebar-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  flex-shrink: 0;
+  font-size: 0.85rem;
 }
 
 .app-main {
@@ -150,6 +193,18 @@ input, select, textarea, button {
   font-weight: 500;
   transition: background 0.15s, color 0.15s;
   border-left: 3px solid transparent;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.app-sidebar--collapsed .sidebar-nav__link {
+  padding: 0.625rem 0;
+  justify-content: center;
+  border-left: none;
+}
+
+.app-sidebar--collapsed .sidebar-section-title {
+  height: 1rem;
 }
 
 .sidebar-nav__link:hover {


### PR DESCRIPTION
## Summary

Adds a collapse/expand toggle to the sidebar navigation for a cleaner UI when more screen space is needed.

## Changes

- **AppLayout**: Manages collapsed state with localStorage persistence
- **Sidebar**: Accepts `collapsed` prop, shows icon-only view when collapsed with tooltips
- **CSS**: Smooth 220px → 48px transition, toggle button styling, collapsed link alignment

## Behavior

- Click the chevron at the top of the sidebar to toggle
- Collapsed state persists across page reloads (localStorage)
- Icons provide at-a-glance navigation; tooltips show labels on hover
- Mobile (≤768px) unchanged — sidebar stays hidden

## Testing

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — success
- `npx vitest run` — 89/91 pass (2 pre-existing authStore failures)