### PR TITLE
feat: add turn-over-turn delta indicators and trend arrows across all metrics

### DIFF
--- a/apps/web/src/components/simulation/DomainPanel.tsx
+++ b/apps/web/src/components/simulation/DomainPanel.tsx
@@ -5,6 +5,8 @@ import { STRESS_THRESHOLDS } from "../../utils/constants";
 interface DomainPanelProps {
   domain: DomainLayer;
   layerState: LayerState | null;
+  previousLayerState?: LayerState | null;
+  isMostChanged?: boolean;
 }
 
 function getStressLevel(stress: number): string {
@@ -15,7 +17,31 @@ function getStressLevel(stress: number): string {
   return "low";
 }
 
-export default function DomainPanel({ domain, layerState }: DomainPanelProps) {
+function DomainDelta({ current, previous, invert = false }: {
+  current: number;
+  previous: number;
+  invert?: boolean;
+}) {
+  const delta = current - previous;
+  if (Math.abs(delta) < 0.001) return null;
+  const isPositive = delta > 0;
+  const isGood = invert ? isPositive : !isPositive;
+  const arrow = isPositive ? "↑" : "↓";
+  const pctDelta = Math.abs(delta * 100).toFixed(1);
+  const cls = isGood ? "domain-delta--good" : "domain-delta--bad";
+  return (
+    <span className={`domain-delta ${cls}`}>
+      {arrow}{pctDelta}%
+    </span>
+  );
+}
+
+export default function DomainPanel({
+  domain,
+  layerState,
+  previousLayerState,
+  isMostChanged = false,
+}: DomainPanelProps) {
   const label = DOMAIN_LABELS[domain];
   const color = DOMAIN_COLORS[domain];
   const stress = layerState?.stress ?? 0;
@@ -23,8 +49,13 @@ export default function DomainPanel({ domain, layerState }: DomainPanelProps) {
   const activity = layerState?.activity_level ?? 0;
   const stressLevel = getStressLevel(stress);
 
+  const panelClass = [
+    "domain-panel",
+    isMostChanged ? "domain-panel--most-changed" : "",
+  ].filter(Boolean).join(" ");
+
   return (
-    <div className="domain-panel">
+    <div className={panelClass}>
       <div className="domain-panel__header">
         <div className="domain-panel__name">
           <span
@@ -32,13 +63,24 @@ export default function DomainPanel({ domain, layerState }: DomainPanelProps) {
             style={{ backgroundColor: color }}
           />
           {label}
+          {isMostChanged && <span className="domain-panel__volatile" title="Most changed this turn">⚡</span>}
         </div>
-        <div className="domain-panel__value">{formatPercent(stress)}</div>
+        <div className="domain-panel__value">
+          {formatPercent(stress)}
+          {previousLayerState && (
+            <DomainDelta current={stress} previous={previousLayerState.stress} />
+          )}
+        </div>
       </div>
 
       <div className="domain-panel__bars">
         <div>
-          <div className="domain-panel__bar-label">Stress</div>
+          <div className="domain-panel__bar-label">
+            Stress
+            {previousLayerState && (
+              <DomainDelta current={stress} previous={previousLayerState.stress} />
+            )}
+          </div>
           <div className="stress-bar">
             <div
               className={`stress-bar__fill stress-bar__fill--${stressLevel}`}
@@ -47,7 +89,16 @@ export default function DomainPanel({ domain, layerState }: DomainPanelProps) {
           </div>
         </div>
         <div>
-          <div className="domain-panel__bar-label">Resilience</div>
+          <div className="domain-panel__bar-label">
+            Resilience
+            {previousLayerState && (
+              <DomainDelta
+                current={resilience}
+                previous={previousLayerState.resilience}
+                invert
+              />
+            )}
+          </div>
           <div className="resilience-bar">
             <div
               className="resilience-bar__fill"

--- a/apps/web/src/components/simulation/MetricsOverview.tsx
+++ b/apps/web/src/components/simulation/MetricsOverview.tsx
@@ -11,6 +11,8 @@ interface MetricsOverviewProps {
   eventCount: number;
   worldState: WorldState | null;
   side?: "blue" | "red";
+  previousOrderParameter?: number;
+  previousWorldState?: WorldState | null;
 }
 
 function findPlayerResources(
@@ -28,6 +30,23 @@ function findPlayerResources(
   return actor?.resources ?? null;
 }
 
+function DeltaBadge({ delta, invert = false }: { delta: number; invert?: boolean }) {
+  if (Math.abs(delta) < 0.001) return null;
+  const isPositive = delta > 0;
+  // For stress/Ψ, positive = worsening (red). For resilience/resources, positive = good (green).
+  const isGood = invert ? isPositive : !isPositive;
+  const arrow = isPositive ? "↑" : "↓";
+  const cls = isGood ? "delta-badge--good" : "delta-badge--bad";
+  const formatted = Math.abs(delta) < 1
+    ? Math.abs(delta).toFixed(2)
+    : Math.round(Math.abs(delta)).toString();
+  return (
+    <span className={`delta-badge ${cls}`}>
+      {arrow}{formatted}
+    </span>
+  );
+}
+
 export default function MetricsOverview({
   orderParameter,
   phase,
@@ -35,6 +54,8 @@ export default function MetricsOverview({
   eventCount,
   worldState,
   side,
+  previousOrderParameter,
+  previousWorldState,
 }: MetricsOverviewProps) {
   let dominantDomain: DomainLayer | null = null;
   let maxStress = 0;
@@ -57,7 +78,33 @@ export default function MetricsOverview({
     avgResilience = count > 0 ? resilienceSum / count : 0;
   }
 
+  // Compute previous avg resilience for delta
+  let prevAvgResilience = 0;
+  if (previousWorldState) {
+    let resSum = 0;
+    let cnt = 0;
+    for (const domain of ALL_DOMAINS) {
+      const layer = previousWorldState.layers[domain];
+      if (layer) {
+        resSum += layer.resilience;
+        cnt++;
+      }
+    }
+    prevAvgResilience = cnt > 0 ? resSum / cnt : 0;
+  }
+
   const resources = findPlayerResources(worldState, side);
+  const prevResources = findPlayerResources(previousWorldState ?? null, side);
+
+  const psiDelta = previousOrderParameter !== undefined
+    ? orderParameter - previousOrderParameter
+    : null;
+  const resDelta = resources !== null && prevResources !== null
+    ? resources - prevResources
+    : null;
+  const resilienceDelta = previousWorldState
+    ? avgResilience - prevAvgResilience
+    : null;
 
   return (
     <div className="metrics-grid">
@@ -71,6 +118,7 @@ export default function MetricsOverview({
         </div>
         <div className="metric-card__value">
           {formatOrderParameter(orderParameter)}
+          {psiDelta !== null && <DeltaBadge delta={psiDelta} />}
         </div>
       </div>
       <div className="metric-card">
@@ -102,7 +150,10 @@ export default function MetricsOverview({
               content="Resource points (RP) are spent when executing actions. Each action has a cost. Resources recover slowly each turn (+2 RP). Running out limits your options."
             />
           </div>
-          <div className="metric-card__value">{Math.round(resources)} RP</div>
+          <div className="metric-card__value">
+            {Math.round(resources)} RP
+            {resDelta !== null && <DeltaBadge delta={resDelta} invert />}
+          </div>
         </div>
       )}
       <div className="metric-card">
@@ -119,7 +170,10 @@ export default function MetricsOverview({
             content="Average defensive posture across all domains. Higher resilience dampens stress growth and spillover. Keep it high to absorb shocks."
           />
         </div>
-        <div className="metric-card__value">{formatPercent(avgResilience)}</div>
+        <div className="metric-card__value">
+          {formatPercent(avgResilience)}
+          {resilienceDelta !== null && <DeltaBadge delta={resilienceDelta} invert />}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useRunStore } from "../../stores/runStore";
 import { useActions } from "../../hooks/useActions";
-import { ALL_DOMAINS } from "../../types/domain";
+import { ALL_DOMAINS, DomainLayer } from "../../types/domain";
 import { Role, TurnResult, WorldState } from "../../types/run";
 import { Phase } from "../../types/phase";
 import PhaseIndicator from "./PhaseIndicator";
@@ -56,8 +56,10 @@ export default function SimulationDashboard({
   side,
 }: SimulationDashboardProps) {
   const worldState = useRunStore((s) => s.worldState);
+  const previousWorldState = useRunStore((s) => s.previousWorldState);
   const currentPhase = useRunStore((s) => s.currentPhase);
   const orderParameter = useRunStore((s) => s.orderParameter);
+  const previousOrderParameter = useRunStore((s) => s.previousOrderParameter);
   const currentTurn = useRunStore((s) => s.currentTurn);
   const events = useRunStore((s) => s.events);
   const legalActions = useRunStore((s) => s.legalActions);
@@ -80,6 +82,23 @@ export default function SimulationDashboard({
     );
     return actor?.resources ?? null;
   })();
+
+  // Find the domain with the largest absolute stress delta
+  const mostChangedDomain = useMemo<DomainLayer | null>(() => {
+    if (!worldState || !previousWorldState) return null;
+    let maxDelta = 0;
+    let result: DomainLayer | null = null;
+    for (const domain of ALL_DOMAINS) {
+      const curr = worldState.layers[domain]?.stress ?? 0;
+      const prev = previousWorldState.layers[domain]?.stress ?? 0;
+      const delta = Math.abs(curr - prev);
+      if (delta > maxDelta) {
+        maxDelta = delta;
+        result = domain;
+      }
+    }
+    return maxDelta > 0.005 ? result : null;
+  }, [worldState, previousWorldState]);
 
   const isTablet = useMediaQuery("(max-width: 1024px)");
   const isMobile = useMediaQuery("(max-width: 768px)");
@@ -261,6 +280,8 @@ export default function SimulationDashboard({
                   eventCount={events.length}
                   worldState={worldState}
                   side={side}
+                  previousOrderParameter={previousOrderParameter}
+                  previousWorldState={previousWorldState}
                 />
                 <DomainStressChart stressHistory={stressHistory} />
               </>
@@ -293,6 +314,8 @@ export default function SimulationDashboard({
                     key={domain}
                     domain={domain}
                     layerState={worldState?.layers[domain] ?? null}
+                    previousLayerState={previousWorldState?.layers[domain] ?? null}
+                    isMostChanged={domain === mostChangedDomain}
                   />
                 ))}
               </div>
@@ -307,6 +330,8 @@ export default function SimulationDashboard({
                 key={domain}
                 domain={domain}
                 layerState={worldState?.layers[domain] ?? null}
+                previousLayerState={previousWorldState?.layers[domain] ?? null}
+                isMostChanged={domain === mostChangedDomain}
               />
             ))}
           </div>
@@ -325,6 +350,8 @@ export default function SimulationDashboard({
               eventCount={events.length}
               worldState={worldState}
               side={side}
+              previousOrderParameter={previousOrderParameter}
+              previousWorldState={previousWorldState}
             />
             <DomainStressChart stressHistory={stressHistory} />
             <EventFeed events={events} />

--- a/apps/web/src/stores/runStore.ts
+++ b/apps/web/src/stores/runStore.ts
@@ -12,8 +12,10 @@ interface StressHistoryEntry {
 interface RunState {
   run: RunRead | null;
   worldState: WorldState | null;
+  previousWorldState: WorldState | null;
   currentPhase: Phase;
   orderParameter: number;
+  previousOrderParameter: number;
   currentTurn: number;
   events: TurnEvent[];
   legalActions: LegalAction[];
@@ -43,8 +45,10 @@ interface RunState {
 const initialState = {
   run: null,
   worldState: null,
+  previousWorldState: null as WorldState | null,
   currentPhase: Phase.CompetitiveNormality,
   orderParameter: 0,
+  previousOrderParameter: 0,
   currentTurn: 0,
   events: [] as TurnEvent[],
   legalActions: [] as LegalAction[],
@@ -81,6 +85,8 @@ export const useRunStore = create<RunState>()((set) => ({
         typeof worldState.turn === "number" ? worldState.turn : state.currentTurn;
 
       return {
+        previousWorldState: state.worldState,
+        previousOrderParameter: state.orderParameter,
         worldState,
         currentPhase: worldState.phase ?? state.currentPhase,
         orderParameter: nextOrderParameter,

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -2180,3 +2180,63 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
   padding-top: 0.5rem;
   border-top: 1px solid var(--border);
 }
+
+/* ── Delta Badges & Indicators ─────────────────────────── */
+.delta-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  margin-left: 0.35rem;
+  animation: delta-flash 0.6s ease-out;
+}
+
+.delta-badge--good {
+  color: #22c55e;
+  background: rgba(34, 197, 94, 0.12);
+}
+
+.delta-badge--bad {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.domain-delta {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.62rem;
+  font-weight: 600;
+  margin-left: 0.25rem;
+  animation: delta-flash 0.6s ease-out;
+}
+
+.domain-delta--good {
+  color: #22c55e;
+}
+
+.domain-delta--bad {
+  color: #ef4444;
+}
+
+.domain-panel--most-changed {
+  border: 1px solid rgba(234, 179, 8, 0.4);
+  box-shadow: 0 0 8px rgba(234, 179, 8, 0.15);
+}
+
+.domain-panel__volatile {
+  font-size: 0.7rem;
+  margin-left: 0.25rem;
+}
+
+@keyframes delta-flash {
+  0% {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Changes

- **runStore**: Added `previousWorldState` and `previousOrderParameter` tracking — `setWorldState` now saves the previous state before updating
- **MetricsOverview**: Delta badges (↑/↓) on Order Parameter (Ψ), Resources, and Avg Resilience cards
- **DomainPanel**: Stress and resilience delta indicators next to bar labels and header value
- **Most-changed domain**: Yellow border + ⚡ icon on the domain with the largest stress delta
- **Animations**: `delta-flash` keyframe for smooth badge entrance
- Color-coded: green = improving, red = worsening

## Files Modified
- `runStore.ts` — Track previous world state and order parameter
- `MetricsOverview.tsx` — Delta badge component + previous state props
- `DomainPanel.tsx` — DomainDelta component + most-changed highlight
- `SimulationDashboard.tsx` — Compute most-changed domain, pass previous state
- `index.css` — Delta badge and most-changed domain styles

## Testing
```
npx vitest run src/stores/runStore.test.ts src/components/simulation/DomainPanel.test.tsx src/components/simulation/MetricsOverview.test.tsx
# ✓ 25 tests passed
npx tsc --noEmit  # No errors
```

Closes #101