### PR TITLE
feat: add action card effect preview on hover with compact indicators

### DIFF
--- a/apps/web/src/components/simulation/ActionCard.tsx
+++ b/apps/web/src/components/simulation/ActionCard.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { LegalAction } from "../../types/run";
 import { DomainLayer, DOMAIN_LABELS } from "../../types/domain";
 import { MIN_INTENSITY, MAX_INTENSITY, INTENSITY_STEP } from "../../utils/constants";
 import { useRunStore } from "../../stores/runStore";
 import { useLocaleAction } from "../../hooks/useScenarioLocale";
-import ActionEffectPreview from "./ActionEffectPreview";
-import ActionEscalationBadge from "./ActionEscalationBadge";
+import ActionEffectPreview, { computeEffects } from "./ActionEffectPreview";
+import ActionEscalationBadge, { getBadgeLevel } from "./ActionEscalationBadge";
 import InfoTooltip from "../common/InfoTooltip";
 
 interface ActionCardProps {
@@ -13,6 +13,7 @@ interface ActionCardProps {
   onSubmit: (intensity: number, selectedDomain: string) => void;
   isSubmitting: boolean;
   side: "blue" | "red";
+  forceExpand?: boolean;
 }
 
 const SPILLOVER_DOMAINS: Record<string, string> = {
@@ -33,6 +34,7 @@ export default function ActionCard({
   onSubmit,
   isSubmitting,
   side,
+  forceExpand,
 }: ActionCardProps) {
   // Derive intensity bounds from parameter_ranges or legacy fields
   const minIntensity =
@@ -55,6 +57,10 @@ export default function ActionCard({
   // Per-card executed state
   const [executed, setExecuted] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
+  const [hoverPreview, setHoverPreview] = useState(false);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const isExpanded = showDetail || forceExpand;
 
   useEffect(() => {
     if (executed) {
@@ -62,6 +68,17 @@ export default function ActionCard({
       return () => clearTimeout(timer);
     }
   }, [executed]);
+
+  const handleMouseEnter = useCallback(() => {
+    if (!isExpanded) {
+      hoverTimer.current = setTimeout(() => setHoverPreview(true), 300);
+    }
+  }, [isExpanded]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimer.current) clearTimeout(hoverTimer.current);
+    setHoverPreview(false);
+  }, []);
 
   // Store state
   const worldState = useRunStore((state) => state.worldState);
@@ -84,8 +101,33 @@ export default function ActionCard({
   const tier = getIntensityTier(intensity);
   const spilloverDomain = SPILLOVER_DOMAINS[action.action_type];
 
+  // Compact preview: compute effects for collapsed summary
+  const effects = computeEffects(action.action_type, intensity, targetDomainState?.resilience ?? 0.5);
+  const escalationLevel = getBadgeLevel(action.action_type, intensity, currentPhase);
+
+  // Cost-efficiency ratio: effect per resource point
+  const costEfficiency = action.resource_cost && action.resource_cost > 0
+    ? Math.abs(effects.primaryStressDelta) / action.resource_cost
+    : null;
+
+  const ESCALATION_ICONS: Record<string, string> = {
+    low: "🟢",
+    medium: "🟡",
+    high: "🟠",
+    critical: "🔴",
+  };
+
+  const formatCompactDelta = (val: number) => {
+    const sign = val >= 0 ? "+" : "−";
+    return `${sign}${Math.abs(val).toFixed(3)}`;
+  };
+
   return (
-    <div className={`action-card${executed ? " action-card--executed" : ""}`}>
+    <div
+      className={`action-card${executed ? " action-card--executed" : ""}`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       <div className="action-card__header">
         <span className="action-card__type">
           {localeAction?.label ?? action.action_type}
@@ -104,10 +146,51 @@ export default function ActionCard({
             onClick={() => setShowDetail((v) => !v)}
             aria-label="Toggle detail panel"
           >
-            {showDetail ? "▲ Details" : "▼ Details"}
+            {isExpanded ? "▲ Details" : "▼ Details"}
           </button>
         </div>
       </div>
+
+      {/* Compact effect indicators — always visible in collapsed state */}
+      {!isExpanded && (
+        <div className="action-card__compact-preview">
+          <span className={`compact-pill compact-pill--stress-${effects.primaryStressDelta >= 0 ? "up" : "down"}`}>
+            stress {formatCompactDelta(effects.primaryStressDelta)}
+          </span>
+          <span className={`compact-pill compact-pill--escalation-${escalationLevel}`}>
+            {ESCALATION_ICONS[escalationLevel]} {escalationLevel}
+          </span>
+          {costEfficiency !== null && (
+            <span className="compact-pill compact-pill--efficiency" title="Effect per resource point">
+              ⚡ {costEfficiency.toFixed(4)}/RP
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Hover preview tooltip — shown after 300ms delay */}
+      {hoverPreview && !isExpanded && (
+        <div className="action-card__hover-preview" role="tooltip">
+          <ActionEffectPreview
+            actionType={action.action_type}
+            targetDomain={selectedDomain}
+            intensity={intensity}
+            domainStress={targetDomainState?.stress ?? 0.5}
+            domainResilience={targetDomainState?.resilience ?? 0.5}
+            side={side}
+          />
+          <ActionEscalationBadge
+            actionType={action.action_type}
+            intensity={intensity}
+            currentPhase={currentPhase}
+          />
+          {spilloverDomain && (
+            <div className="effect-spillover-note">
+              ⚠ Spillover → {domainLabel(spilloverDomain)}
+            </div>
+          )}
+        </div>
+      )}
 
       {localeAction?.flavour && (
         <div className="action-card__flavour">{localeAction.flavour}</div>
@@ -180,7 +263,7 @@ export default function ActionCard({
         </div>
       </div>
 
-      {showDetail && (
+      {isExpanded && (
         <div className="action-card__detail-panel">
           <div className="detail-row">
             <ActionEffectPreview

--- a/apps/web/src/components/simulation/ActionEffectPreview.tsx
+++ b/apps/web/src/components/simulation/ActionEffectPreview.tsx
@@ -14,7 +14,7 @@ interface EffectResult {
   spilloverNote: string | null;
 }
 
-function computeEffects(
+export function computeEffects(
   actionType: string,
   intensity: number,
   resilience: number

--- a/apps/web/src/components/simulation/ActionEscalationBadge.tsx
+++ b/apps/web/src/components/simulation/ActionEscalationBadge.tsx
@@ -8,7 +8,7 @@ interface ActionEscalationBadgeProps {
   currentPhase: string;
 }
 
-type BadgeLevel = "low" | "medium" | "high" | "critical";
+export type BadgeLevel = "low" | "medium" | "high" | "critical";
 
 const LOW_ACTIONS = new Set([
   "DeEscalate",
@@ -37,7 +37,7 @@ function getPhaseIndex(phaseName: string): number {
   return idx === -1 ? 0 : idx;
 }
 
-function getBadgeLevel(
+export function getBadgeLevel(
   actionType: string,
   intensity: number,
   currentPhase: string

--- a/apps/web/src/components/simulation/ActionPanel.tsx
+++ b/apps/web/src/components/simulation/ActionPanel.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useCallback } from "react";
 import { LegalAction } from "../../types/run";
 import { ActionSubmit } from "../../types/action";
 import ActionCard from "./ActionCard";
@@ -15,17 +16,49 @@ export default function ActionPanel({
   isSubmitting,
   side,
 }: ActionPanelProps) {
+  const [expandAll, setExpandAll] = useState(false);
+
+  // Keyboard shortcut: 'e' toggles expand all
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (
+      e.key === "e" &&
+      !e.ctrlKey && !e.metaKey && !e.altKey &&
+      !(e.target instanceof HTMLInputElement) &&
+      !(e.target instanceof HTMLTextAreaElement) &&
+      !(e.target instanceof HTMLSelectElement)
+    ) {
+      setExpandAll((v) => !v);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
   return (
     <div className="card">
-      <div className="card__title">
-        Available Actions
+      <div className="card__title" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <span>
+          Available Actions
+          {legalActions.length > 0 && (
+            <span
+              className="badge badge--blue"
+              style={{ marginLeft: "0.5rem" }}
+            >
+              {legalActions.length}
+            </span>
+          )}
+        </span>
         {legalActions.length > 0 && (
-          <span
-            className="badge badge--blue"
-            style={{ marginLeft: "0.5rem" }}
+          <button
+            className="btn btn--xs btn--ghost"
+            onClick={() => setExpandAll((v) => !v)}
+            title="Toggle all details (E)"
+            style={{ fontSize: "0.72rem", padding: "0.15rem 0.5rem" }}
           >
-            {legalActions.length}
-          </span>
+            {expandAll ? "▲ Collapse All" : "▼ Expand All"}
+          </button>
         )}
       </div>
       <div className="mt-1" style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
@@ -49,6 +82,7 @@ export default function ActionPanel({
               }
               isSubmitting={isSubmitting}
               side={side}
+              forceExpand={expandAll}
             />
           ))
         )}

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -2240,3 +2240,98 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
     transform: translateY(0);
   }
 }
+
+/* ── Action Card Compact Preview ─────────────────────────── */
+.action-card__compact-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  padding: 0.25rem 0.75rem 0.35rem;
+}
+
+.compact-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+.compact-pill--stress-up {
+  background: rgba(239, 68, 68, 0.12);
+  color: #ef4444;
+}
+.compact-pill--stress-down {
+  background: rgba(34, 197, 94, 0.12);
+  color: #22c55e;
+}
+
+.compact-pill--escalation-low {
+  background: rgba(34, 197, 94, 0.10);
+  color: #22c55e;
+}
+.compact-pill--escalation-medium {
+  background: rgba(234, 179, 8, 0.12);
+  color: #eab308;
+}
+.compact-pill--escalation-high {
+  background: rgba(249, 115, 22, 0.12);
+  color: #f97316;
+}
+.compact-pill--escalation-critical {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.compact-pill--efficiency {
+  background: rgba(99, 102, 241, 0.10);
+  color: #818cf8;
+}
+
+/* ── Action Card Hover Preview Tooltip ───────────────────── */
+.action-card {
+  position: relative;
+}
+
+.action-card__hover-preview {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(100% + 4px);
+  z-index: 50;
+  background: var(--bg-elevated, #1e293b);
+  border: 1px solid var(--border, #334155);
+  border-radius: var(--radius, 0.5rem);
+  padding: 0.6rem 0.75rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  animation: hover-preview-in 0.15s ease-out;
+  pointer-events: none;
+}
+
+@keyframes hover-preview-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Expand All / Collapse All button ────────────────────── */
+.btn--xs {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+  line-height: 1.2;
+}
+
+.btn--ghost {
+  background: transparent;
+  border: 1px solid var(--border, #334155);
+  color: var(--text-muted, #94a3b8);
+  cursor: pointer;
+  border-radius: var(--radius, 0.5rem);
+  transition: background 0.15s, color 0.15s;
+}
+.btn--ghost:hover {
+  background: var(--bg-elevated, #1e293b);
+  color: var(--text-primary, #f1f5f9);
+}


### PR DESCRIPTION
## Changes

- **Compact effect indicators**: Collapsed action cards now show stress delta pill, escalation risk badge, and cost-efficiency ratio (effect/RP) inline
- **Hover preview tooltip**: 300ms delayed tooltip shows full ActionEffectPreview + ActionEscalationBadge + spillover warning on hover (collapsed cards only)
- **Expand All toggle**: ActionPanel header button + keyboard shortcut (`E`) to expand/collapse all card details simultaneously
- **Exported helpers**: `computeEffects()` from ActionEffectPreview and `getBadgeLevel()`/`BadgeLevel` from ActionEscalationBadge now exported for reuse

## Files Modified
- `ActionCard.tsx` — Compact preview row, hover tooltip, forceExpand prop, hover timer logic
- `ActionPanel.tsx` — Expand All toggle button + keyboard shortcut
- `ActionEffectPreview.tsx` — Exported `computeEffects`
- `ActionEscalationBadge.tsx` — Exported `getBadgeLevel` and `BadgeLevel` type
- `index.css` — Compact pill, hover preview, ghost button styles

## Testing
```
npx tsc --noEmit  # No errors
npx vitest run    # 95 tests passed (2 pre-existing authStore failures)
```

Closes #97