### PR TITLE
feat: add domain coupling visualization with interactive graph and event callouts

### DIFF
--- a/apps/web/src/components/simulation/CouplingGraph.tsx
+++ b/apps/web/src/components/simulation/CouplingGraph.tsx
@@ -1,8 +1,11 @@
 import { useMemo } from "react";
 import { ALL_DOMAINS, DomainLayer, DOMAIN_LABELS, DOMAIN_COLORS } from "../../types/domain";
+import { LayerState } from "../../types/domain";
 
 interface CouplingGraphProps {
   couplingMatrix: Record<string, Record<string, number>>;
+  layers?: Record<DomainLayer, LayerState>;
+  activeCouplings?: Array<{ source: string; target: string }>;
 }
 
 interface NodePosition {
@@ -11,11 +14,17 @@ interface NodePosition {
   domain: DomainLayer;
 }
 
-export default function CouplingGraph({ couplingMatrix }: CouplingGraphProps) {
-  const size = 300;
+function edgeColor(weight: number): string {
+  if (weight >= 0.5) return "#ef4444";
+  if (weight >= 0.25) return "#eab308";
+  return "#22c55e";
+}
+
+export default function CouplingGraph({ couplingMatrix, layers, activeCouplings = [] }: CouplingGraphProps) {
+  const size = 340;
   const cx = size / 2;
   const cy = size / 2;
-  const radius = 110;
+  const radius = 120;
 
   const nodes: NodePosition[] = useMemo(() => {
     return ALL_DOMAINS.map((domain, i) => {
@@ -28,11 +37,21 @@ export default function CouplingGraph({ couplingMatrix }: CouplingGraphProps) {
     });
   }, [cx, cy]);
 
+  const activeSet = useMemo(() => {
+    const s = new Set<string>();
+    for (const c of activeCouplings) {
+      s.add(`${c.source}|${c.target}`);
+      s.add(`${c.target}|${c.source}`);
+    }
+    return s;
+  }, [activeCouplings]);
+
   const edges = useMemo(() => {
     const result: {
       from: NodePosition;
       to: NodePosition;
       weight: number;
+      active: boolean;
     }[] = [];
 
     for (let i = 0; i < nodes.length; i++) {
@@ -43,56 +62,90 @@ export default function CouplingGraph({ couplingMatrix }: CouplingGraphProps) {
         const w2 = couplingMatrix[to.domain]?.[from.domain] ?? 0;
         const weight = Math.max(Math.abs(w1), Math.abs(w2));
         if (weight > 0.01) {
-          result.push({ from, to, weight });
+          const active = activeSet.has(`${from.domain}|${to.domain}`);
+          result.push({ from, to, weight, active });
         }
       }
     }
+    // Sort so active edges draw on top
+    result.sort((a, b) => (a.active === b.active ? 0 : a.active ? 1 : -1));
     return result;
-  }, [nodes, couplingMatrix]);
+  }, [nodes, couplingMatrix, activeSet]);
 
   return (
     <div className="coupling-graph">
       <div className="card__title" style={{ padding: "0.5rem 0.5rem 0" }}>
-        Domain Coupling
+        Domain Coupling Map
+      </div>
+      <div className="coupling-graph__legend">
+        <span className="coupling-legend-item"><span className="coupling-dot" style={{ background: "#22c55e" }} /> Weak</span>
+        <span className="coupling-legend-item"><span className="coupling-dot" style={{ background: "#eab308" }} /> Medium</span>
+        <span className="coupling-legend-item"><span className="coupling-dot" style={{ background: "#ef4444" }} /> Strong</span>
+        {activeCouplings.length > 0 && (
+          <span className="coupling-legend-item"><span className="coupling-dot coupling-dot--pulse" /> Active</span>
+        )}
       </div>
       <svg viewBox={`0 0 ${size} ${size}`} width="100%" height="auto">
-        {edges.map((edge, i) => (
-          <line
-            key={i}
-            x1={edge.from.x}
-            y1={edge.from.y}
-            x2={edge.to.x}
-            y2={edge.to.y}
-            stroke="#4a4e69"
-            strokeWidth={Math.max(0.5, edge.weight * 4)}
-            strokeOpacity={0.3 + edge.weight * 0.5}
-          />
-        ))}
-        {nodes.map((node) => (
-          <g key={node.domain}>
-            <circle
-              cx={node.x}
-              cy={node.y}
-              r={12}
-              fill={DOMAIN_COLORS[node.domain]}
-              fillOpacity={0.8}
-              stroke={DOMAIN_COLORS[node.domain]}
-              strokeWidth={1.5}
-            />
-            <text
-              x={node.x}
-              y={node.y + 22}
-              textAnchor="middle"
-              fill="#a1a1aa"
-              fontSize={7}
-              fontFamily="sans-serif"
-            >
-              {DOMAIN_LABELS[node.domain].length > 12
-                ? DOMAIN_LABELS[node.domain].slice(0, 12) + "..."
-                : DOMAIN_LABELS[node.domain]}
-            </text>
-          </g>
-        ))}
+        {edges.map((edge, i) => {
+          const midX = (edge.from.x + edge.to.x) / 2;
+          const midY = (edge.from.y + edge.to.y) / 2;
+          return (
+            <g key={i}>
+              <line
+                x1={edge.from.x}
+                y1={edge.from.y}
+                x2={edge.to.x}
+                y2={edge.to.y}
+                stroke={edge.active ? "#60a5fa" : edgeColor(edge.weight)}
+                strokeWidth={Math.max(1, edge.weight * 5)}
+                strokeOpacity={edge.active ? 0.9 : 0.3 + edge.weight * 0.4}
+                className={edge.active ? "coupling-edge--active" : ""}
+              />
+              {edge.weight >= 0.1 && (
+                <text
+                  x={midX}
+                  y={midY - 4}
+                  textAnchor="middle"
+                  fill={edge.active ? "#93c5fd" : "#94a3b8"}
+                  fontSize={7}
+                  fontFamily="sans-serif"
+                  fontWeight={edge.active ? 700 : 400}
+                >
+                  {edge.weight.toFixed(2)}
+                </text>
+              )}
+            </g>
+          );
+        })}
+        {nodes.map((node) => {
+          const stress = layers?.[node.domain]?.stress ?? 0.5;
+          const nodeRadius = 10 + stress * 8;
+          return (
+            <g key={node.domain}>
+              <circle
+                cx={node.x}
+                cy={node.y}
+                r={nodeRadius}
+                fill={DOMAIN_COLORS[node.domain]}
+                fillOpacity={0.8}
+                stroke={DOMAIN_COLORS[node.domain]}
+                strokeWidth={1.5}
+              />
+              <text
+                x={node.x}
+                y={node.y + nodeRadius + 10}
+                textAnchor="middle"
+                fill="#a1a1aa"
+                fontSize={7}
+                fontFamily="sans-serif"
+              >
+                {DOMAIN_LABELS[node.domain].length > 12
+                  ? DOMAIN_LABELS[node.domain].slice(0, 12) + "..."
+                  : DOMAIN_LABELS[node.domain]}
+              </text>
+            </g>
+          );
+        })}
       </svg>
     </div>
   );

--- a/apps/web/src/components/simulation/EventFeed.test.tsx
+++ b/apps/web/src/components/simulation/EventFeed.test.tsx
@@ -45,7 +45,7 @@ describe("EventFeed", () => {
     ["action", "ACTION"],
     ["stochastic", "EVENT"],
     ["phase_transition", "PHASE"],
-    ["coupling_effect", "EFFECT"],
+    ["coupling_effect", "COUPLING"],
     ["ai_action", "OPPONENT"],
     ["narrative", "SITREP"],
     ["intel", "INTEL"],

--- a/apps/web/src/components/simulation/EventFeed.tsx
+++ b/apps/web/src/components/simulation/EventFeed.tsx
@@ -3,6 +3,7 @@ import { DomainLayer, DOMAIN_LABELS } from "../../types/domain";
 
 interface EventFeedProps {
   events: TurnEvent[];
+  couplingMatrix?: Record<string, Record<string, number>>;
 }
 
 function getEventClass(type: TurnEvent["type"]): string {
@@ -37,7 +38,7 @@ function getTypeBadge(type: TurnEvent["type"]): { label: string; className: stri
     case "phase_transition":
       return { label: "PHASE", className: "badge badge--red" };
     case "coupling_effect":
-      return { label: "EFFECT", className: "badge badge--purple" };
+      return { label: "COUPLING", className: "badge badge--purple" };
     case "ai_action":
       return { label: "OPPONENT", className: "badge badge--orange" };
     case "narrative":
@@ -56,7 +57,33 @@ function getDomainLabel(domain: string | null): string | null {
   return DOMAIN_LABELS[domain as DomainLayer] ?? domain;
 }
 
-export default function EventFeed({ events }: EventFeedProps) {
+function parseCouplingInfo(
+  description: string,
+  domain: DomainLayer | null,
+  couplingMatrix?: Record<string, Record<string, number>>
+): { source: string; target: string; weight: string } | null {
+  // Try to extract source→target from description patterns like:
+  // "Coupling effect from Cyber to Energy" or "Cyber stress spilled over to Energy"
+  const fromTo = description.match(/from\s+(\w+)\s+to\s+(\w+)/i)
+    ?? description.match(/(\w+)\s+(?:stress\s+)?spill(?:ed)?\s+(?:over\s+)?to\s+(\w+)/i)
+    ?? description.match(/(\w+)\s*→\s*(\w+)/);
+
+  if (fromTo) {
+    const source = getDomainLabel(fromTo[1]) ?? fromTo[1];
+    const target = getDomainLabel(fromTo[2]) ?? fromTo[2];
+    const w = couplingMatrix?.[fromTo[1]]?.[fromTo[2]] ?? couplingMatrix?.[fromTo[2]]?.[fromTo[1]];
+    return { source, target, weight: w != null ? w.toFixed(2) : "?" };
+  }
+
+  // Fallback: if domain is set, use it as target
+  if (domain) {
+    const target = getDomainLabel(domain) ?? domain;
+    return { source: "?", target, weight: "?" };
+  }
+  return null;
+}
+
+export default function EventFeed({ events, couplingMatrix }: EventFeedProps) {
   return (
     <div className="card">
       <div className="card__title">Event Feed</div>
@@ -72,8 +99,12 @@ export default function EventFeed({ events }: EventFeedProps) {
           events.map((event, idx) => {
             const badge = getTypeBadge(event.type);
             const domainLabel = getDomainLabel(event.domain);
-            // First few events get "new" animation class
             const isNew = idx < 3;
+
+            // Coupling callout
+            const couplingInfo = event.type === "coupling_effect"
+              ? parseCouplingInfo(event.description, event.domain, couplingMatrix)
+              : null;
 
             return (
               <div
@@ -84,10 +115,22 @@ export default function EventFeed({ events }: EventFeedProps) {
                 <span className={`event-item__type-badge ${badge.className}`}>
                   {badge.label}
                 </span>
-                {domainLabel && (
+                {domainLabel && event.type !== "coupling_effect" && (
                   <span className="event-item__domain">{domainLabel}</span>
                 )}
-                <span className="event-item__text">{event.description}</span>
+                {couplingInfo ? (
+                  <span className="event-item__text">
+                    <span className="coupling-callout">
+                      <span className="coupling-callout__source">{couplingInfo.source}</span>
+                      <span className="coupling-callout__arrow"> → </span>
+                      <span className="coupling-callout__target">{couplingInfo.target}</span>
+                      <span className="coupling-callout__weight">(w: {couplingInfo.weight})</span>
+                    </span>
+                    {" "}{event.description}
+                  </span>
+                ) : (
+                  <span className="event-item__text">{event.description}</span>
+                )}
               </div>
             );
           })

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -14,6 +14,7 @@ import ActionPanel from "./ActionPanel";
 import AiMovePanel from "../../components/ai/AiMovePanel";
 import BattlespaceCanvas from "./BattlespaceCanvas";
 import DomainStressChart from "./DomainStressChart";
+import CouplingGraph from "./CouplingGraph";
 import AfterActionReport, { DomainDelta, computeDomainDeltas } from "./AfterActionReport";
 import ScenarioBriefing from "./ScenarioBriefing";
 import Dialog from "../common/Dialog";
@@ -106,6 +107,7 @@ export default function SimulationDashboard({
   const [aarData, setAarData] = useState<AarData | null>(null);
   const [advanceErrorMessage, setAdvanceErrorMessage] = useState<string | null>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [showCouplingGraph, setShowCouplingGraph] = useState(false);
   const prevWorldStateRef = useRef<WorldState | null>(null);
   const isMountedRef = useRef(true);
   const [activeMobileTab, setActiveMobileTab] =
@@ -132,6 +134,20 @@ export default function SimulationDashboard({
       setActiveMobileTab("overview");
     }
   }, [isMobile]);
+
+  // Extract active coupling pairs from current turn events
+  const activeCouplings = useMemo(() => {
+    return events
+      .filter((e) => e.type === "coupling_effect" && e.turn === currentTurn)
+      .map((e) => {
+        const match = e.description.match(/from\s+(\w+)\s+to\s+(\w+)/i)
+          ?? e.description.match(/(\w+)\s+(?:stress\s+)?spill(?:ed)?\s+(?:over\s+)?to\s+(\w+)/i);
+        if (match) return { source: match[1], target: match[2] };
+        if (e.domain) return { source: "unknown", target: e.domain };
+        return null;
+      })
+      .filter((c): c is { source: string; target: string } => c !== null);
+  }, [events, currentTurn]);
 
   function handleAdvanceTurn() {
     prevWorldStateRef.current = worldState;
@@ -195,8 +211,12 @@ export default function SimulationDashboard({
         e.preventDefault();
         setShowShortcuts(true);
       }
+      if (!isFormElement && e.key === "c" && !e.ctrlKey && !e.metaKey) {
+        setShowCouplingGraph((v) => !v);
+      }
       if (e.key === "Escape") {
         setShowShortcuts(false);
+        setShowCouplingGraph(false);
       }
     };
 
@@ -302,7 +322,7 @@ export default function SimulationDashboard({
                     side={side}
                   />
                 )}
-                <EventFeed events={events} />
+                <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} />
                 {aiMoves.length > 0 && <AiMovePanel latestMove={aiMoves[0]} />}
               </>
             )}
@@ -354,7 +374,16 @@ export default function SimulationDashboard({
               previousWorldState={previousWorldState}
             />
             <DomainStressChart stressHistory={stressHistory} />
-            <EventFeed events={events} />
+            <div style={{ textAlign: "center", margin: "0.3rem 0" }}>
+              <button
+                className="btn btn--sm btn--ghost"
+                onClick={() => setShowCouplingGraph(true)}
+                title="View domain coupling map (C)"
+              >
+                🔗 View Couplings
+              </button>
+            </div>
+            <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} />
           </div>
 
           <div className="sim-layout__right">
@@ -389,6 +418,25 @@ export default function SimulationDashboard({
       )}
 
       <Dialog
+        open={showCouplingGraph}
+        onClose={() => setShowCouplingGraph(false)}
+        title="Domain Coupling Map"
+        actions={
+          <button className="btn btn--primary btn--sm" onClick={() => setShowCouplingGraph(false)}>
+            Close
+          </button>
+        }
+      >
+        {worldState?.coupling_matrix && (
+          <CouplingGraph
+            couplingMatrix={worldState.coupling_matrix}
+            layers={worldState.layers}
+            activeCouplings={activeCouplings}
+          />
+        )}
+      </Dialog>
+
+      <Dialog
         open={showShortcuts}
         onClose={() => setShowShortcuts(false)}
         title="Keyboard Shortcuts"
@@ -421,6 +469,14 @@ export default function SimulationDashboard({
           <li className="shortcut-list__item">
             <span>Navigate tutorial steps</span>
             <span className="shortcut-key">↑ ↓</span>
+          </li>
+          <li className="shortcut-list__item">
+            <span>Toggle coupling graph</span>
+            <span className="shortcut-key">C</span>
+          </li>
+          <li className="shortcut-list__item">
+            <span>Expand/collapse all action cards</span>
+            <span className="shortcut-key">E</span>
           </li>
         </ul>
       </Dialog>

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -2335,3 +2335,73 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
   background: var(--bg-elevated, #1e293b);
   color: var(--text-primary, #f1f5f9);
 }
+
+/* ── Coupling Graph Enhancements ─────────────────────────── */
+.coupling-graph__legend {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.7rem;
+  color: var(--text-muted, #94a3b8);
+}
+
+.coupling-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.coupling-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.coupling-dot--pulse {
+  background: #60a5fa;
+  animation: coupling-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes coupling-pulse {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.4); }
+}
+
+.coupling-edge--active {
+  animation: coupling-edge-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes coupling-edge-pulse {
+  0%, 100% { stroke-opacity: 0.5; }
+  50% { stroke-opacity: 1; }
+}
+
+/* ── Coupling Callout in Event Feed ──────────────────────── */
+.coupling-callout {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  margin-right: 0.35rem;
+}
+
+.coupling-callout__source {
+  color: #818cf8;
+}
+
+.coupling-callout__arrow {
+  color: var(--text-muted, #94a3b8);
+}
+
+.coupling-callout__target {
+  color: #f472b6;
+}
+
+.coupling-callout__weight {
+  color: var(--text-muted, #94a3b8);
+  font-weight: 400;
+  font-size: 0.68rem;
+  margin-left: 0.15rem;
+}


### PR DESCRIPTION
## Changes

- **CouplingGraph integration**: Orphaned component now accessible via toggleable Dialog modal from the simulation dashboard
- **Enhanced graph**: Edge weight labels (≥0.1), color-coded by strength (green=weak, yellow=medium, red=strong), node sizing proportional to stress
- **Active coupling highlights**: Current-turn coupling events pulse with blue animation on the graph
- **Coupling callouts**: EventFeed now shows `Source → Target (w: 0.XX)` inline for coupling_effect events with parsed domain labels
- **Keyboard shortcut**: `C` toggles the coupling graph; added to shortcuts help dialog along with `E` (expand all)
- **Legend**: Visual guide for weak/medium/strong/active coupling indicators

## Files Modified
- `CouplingGraph.tsx` — Enhanced with labels, colors, stress-sized nodes, active edge highlights, legend
- `EventFeed.tsx` — Added `couplingMatrix` prop, `parseCouplingInfo()`, coupling callout rendering
- `EventFeed.test.tsx` — Updated badge label from EFFECT to COUPLING
- `SimulationDashboard.tsx` — Integrated CouplingGraph Dialog, `C` shortcut, activeCouplings memo, View Couplings button
- `index.css` — Coupling graph legend, edge animation, callout styles

## Testing
```
npx tsc --noEmit  # No errors
npx vitest run    # 95 tests passed (2 pre-existing authStore failures)
```

Closes #98