### PR TITLE
feat: add domain panel hover interaction and detail popover

### DIFF
--- a/apps/web/src/components/simulation/DomainPanel.tsx
+++ b/apps/web/src/components/simulation/DomainPanel.tsx
@@ -1,14 +1,37 @@
+import { useState } from "react";
+import { TurnEvent } from "../../types/run";
 import { DomainLayer, DOMAIN_LABELS, DOMAIN_COLORS, LayerState } from "../../types/domain";
 import { formatPercent } from "../../utils/formatters";
 import { STRESS_THRESHOLDS } from "../../utils/constants";
 import { DOMAIN_DESCRIPTIONS } from "../../data/glossary";
 import InfoTooltip from "../common/InfoTooltip";
 
+// Human-readable labels for domain variables
+const VARIABLE_LABELS: Record<string, string> = {
+  troop_readiness: "Troop Readiness",
+  pipeline_integrity: "Pipeline Integrity",
+  disinformation_level: "Disinfo Level",
+  government_stability: "Gov. Stability",
+  satellite_coverage: "Satellite Coverage",
+  bandwidth_capacity: "Bandwidth Capacity",
+  trade_flow: "Trade Flow",
+  port_capacity: "Port Capacity",
+  supply_chain_integrity: "Supply Chain",
+  public_sentiment: "Public Sentiment",
+  media_control: "Media Control",
+  diplomatic_leverage: "Diplomatic Leverage",
+  cyber_defense: "Cyber Defense",
+  power_grid: "Power Grid",
+  fiscal_reserves: "Fiscal Reserves",
+};
+
 interface DomainPanelProps {
   domain: DomainLayer;
   layerState: LayerState | null;
   previousLayerState?: LayerState | null;
   isMostChanged?: boolean;
+  couplingMatrix?: Record<string, Record<string, number>>;
+  recentEvents?: TurnEvent[];
 }
 
 function getStressLevel(stress: number): string {
@@ -38,26 +61,61 @@ function DomainDelta({ current, previous, invert = false }: {
   );
 }
 
+function StressTrend({ current, previous }: { current: number; previous?: number }) {
+  if (previous == null) return <span className="dp-trend dp-trend--stable">→</span>;
+  const delta = current - previous;
+  if (Math.abs(delta) < 0.005) return <span className="dp-trend dp-trend--stable">→</span>;
+  if (delta > 0) return <span className="dp-trend dp-trend--rising">↑</span>;
+  return <span className="dp-trend dp-trend--falling">↓</span>;
+}
+
 export default function DomainPanel({
   domain,
   layerState,
   previousLayerState,
   isMostChanged = false,
+  couplingMatrix,
+  recentEvents,
 }: DomainPanelProps) {
+  const [expanded, setExpanded] = useState(false);
   const label = DOMAIN_LABELS[domain];
   const color = DOMAIN_COLORS[domain];
   const stress = layerState?.stress ?? 0;
   const resilience = layerState?.resilience ?? 0;
   const activity = layerState?.activity_level ?? 0;
+  const friction = layerState?.friction ?? 0;
+  const variables = layerState?.variables ?? {};
   const stressLevel = getStressLevel(stress);
+  const isCritical = stress * 100 >= STRESS_THRESHOLDS.CRITICAL;
+
+  // Get coupled domains from the coupling matrix
+  const coupledDomains = couplingMatrix?.[domain]
+    ? Object.entries(couplingMatrix[domain])
+        .filter(([, w]) => Math.abs(w) > 0.01)
+        .sort((a, b) => Math.abs(b[1]) - Math.abs(a[1]))
+    : [];
+
+  // Recent events for this domain (last 3)
+  const domainEvents = (recentEvents ?? [])
+    .filter((e) => e.domain === domain)
+    .slice(0, 3);
 
   const panelClass = [
     "domain-panel",
     isMostChanged ? "domain-panel--most-changed" : "",
+    isCritical ? "domain-panel--critical" : "",
+    expanded ? "domain-panel--expanded" : "",
   ].filter(Boolean).join(" ");
 
   return (
-    <div className={panelClass}>
+    <div
+      className={panelClass}
+      onClick={() => setExpanded((v) => !v)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setExpanded((v) => !v); } }}
+      style={{ cursor: "pointer" }}
+    >
       <div className="domain-panel__header">
         <div className="domain-panel__name">
           <span
@@ -76,12 +134,14 @@ export default function DomainPanel({
             }
           />
           {isMostChanged && <span className="domain-panel__volatile" title="Most changed this turn">⚡</span>}
+          <StressTrend current={stress} previous={previousLayerState?.stress} />
         </div>
         <div className="domain-panel__value">
           {formatPercent(stress)}
           {previousLayerState && (
             <DomainDelta current={stress} previous={previousLayerState.stress} />
           )}
+          <span className="domain-panel__chevron">{expanded ? "▾" : "▸"}</span>
         </div>
       </div>
 
@@ -127,6 +187,75 @@ export default function DomainPanel({
           </div>
         )}
       </div>
+
+      {expanded && (
+        <div className="domain-panel__detail" onClick={(e) => e.stopPropagation()}>
+          {/* Friction */}
+          <div className="dp-detail-section">
+            <div className="dp-detail-section__title">
+              Friction
+              <InfoTooltip
+                label="About friction"
+                content="Friction dampens how quickly stress changes in this domain. Higher friction = slower stress response."
+              />
+            </div>
+            <div className="dp-detail-metric">
+              <div className="dp-detail-metric__bar">
+                <div className="dp-detail-metric__fill" style={{ width: `${friction * 100}%`, background: "#f59e0b" }} />
+              </div>
+              <span className="dp-detail-metric__value">{formatPercent(friction)}</span>
+            </div>
+          </div>
+
+          {/* Domain variables */}
+          {Object.keys(variables).length > 0 && (
+            <div className="dp-detail-section">
+              <div className="dp-detail-section__title">Domain Variables</div>
+              <div className="dp-detail-vars">
+                {Object.entries(variables).map(([key, value]) => (
+                  <div key={key} className="dp-detail-var">
+                    <span className="dp-detail-var__label">{VARIABLE_LABELS[key] ?? key}</span>
+                    <span className="dp-detail-var__value">{typeof value === "number" ? (value < 1 ? formatPercent(value) : value.toFixed(1)) : String(value)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Coupled domains */}
+          {coupledDomains.length > 0 && (
+            <div className="dp-detail-section">
+              <div className="dp-detail-section__title">Coupled Domains</div>
+              <div className="dp-detail-couplings">
+                {coupledDomains.slice(0, 5).map(([target, weight]) => (
+                  <div key={target} className="dp-detail-coupling">
+                    <span className="dp-detail-coupling__arrow">→</span>
+                    <span className="dp-detail-coupling__name">{DOMAIN_LABELS[target as DomainLayer] ?? target}</span>
+                    <span className={`dp-detail-coupling__weight ${weight > 0 ? "dp-detail-coupling__weight--pos" : "dp-detail-coupling__weight--neg"}`}>
+                      {weight > 0 ? "+" : ""}{weight.toFixed(2)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Recent events */}
+          {domainEvents.length > 0 && (
+            <div className="dp-detail-section">
+              <div className="dp-detail-section__title">Recent Events</div>
+              <div className="dp-detail-events">
+                {domainEvents.map((e) => (
+                  <div key={e.id} className="dp-detail-event">
+                    <span className="dp-detail-event__turn">T{e.turn}</span>
+                    <span className="dp-detail-event__desc">{e.description}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -342,6 +342,8 @@ export default function SimulationDashboard({
                     layerState={worldState?.layers[domain] ?? null}
                     previousLayerState={previousWorldState?.layers[domain] ?? null}
                     isMostChanged={domain === mostChangedDomain}
+                    couplingMatrix={worldState?.coupling_matrix}
+                    recentEvents={events}
                   />
                 ))}
               </div>
@@ -358,6 +360,8 @@ export default function SimulationDashboard({
                 layerState={worldState?.layers[domain] ?? null}
                 previousLayerState={previousWorldState?.layers[domain] ?? null}
                 isMostChanged={domain === mostChangedDomain}
+                couplingMatrix={worldState?.coupling_matrix}
+                recentEvents={events}
               />
             ))}
           </div>

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -2604,3 +2604,143 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
 .event-item__detail-value {
   color: var(--text-primary, #f1f5f9);
 }
+
+/* ── Domain panel expand & hover ── */
+.domain-panel {
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+.domain-panel:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  border-color: var(--primary, #3b82f6);
+}
+.domain-panel--critical {
+  animation: dp-critical-pulse 2s ease-in-out infinite;
+  border-color: #ef4444;
+}
+@keyframes dp-critical-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
+  50% { box-shadow: 0 0 8px 2px rgba(239, 68, 68, 0.35); }
+}
+.domain-panel--expanded {
+  border-color: var(--primary, #3b82f6);
+  box-shadow: 0 2px 12px rgba(59, 130, 246, 0.15);
+}
+.domain-panel__chevron {
+  font-size: 0.7rem;
+  color: var(--text-muted, #94a3b8);
+  margin-left: 0.25rem;
+}
+.dp-trend {
+  font-size: 0.7rem;
+  margin-left: 0.2rem;
+  font-weight: 700;
+}
+.dp-trend--rising { color: #ef4444; }
+.dp-trend--falling { color: #22c55e; }
+.dp-trend--stable { color: var(--text-muted, #94a3b8); }
+
+.domain-panel__detail {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border, #334155);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.dp-detail-section__title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #94a3b8);
+  margin-bottom: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.dp-detail-metric {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.dp-detail-metric__bar {
+  flex: 1;
+  height: 6px;
+  background: var(--bg-elevated, #1e293b);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.dp-detail-metric__fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+.dp-detail-metric__value {
+  font-size: 0.72rem;
+  color: var(--text-primary, #f1f5f9);
+  min-width: 2.5rem;
+  text-align: right;
+}
+.dp-detail-vars {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.15rem 0.5rem;
+}
+.dp-detail-var {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+}
+.dp-detail-var__label {
+  color: var(--text-muted, #94a3b8);
+}
+.dp-detail-var__value {
+  color: var(--text-primary, #f1f5f9);
+  font-weight: 600;
+}
+.dp-detail-couplings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.dp-detail-coupling {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+}
+.dp-detail-coupling__arrow {
+  color: var(--text-muted, #94a3b8);
+}
+.dp-detail-coupling__name {
+  color: var(--text-primary, #f1f5f9);
+}
+.dp-detail-coupling__weight {
+  margin-left: auto;
+  font-weight: 600;
+  font-size: 0.68rem;
+}
+.dp-detail-coupling__weight--pos { color: #ef4444; }
+.dp-detail-coupling__weight--neg { color: #22c55e; }
+.dp-detail-events {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.dp-detail-event {
+  display: flex;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+}
+.dp-detail-event__turn {
+  color: var(--text-muted, #94a3b8);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.dp-detail-event__desc {
+  color: var(--text-secondary, #cbd5e1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
Adds interactive hover states and click-to-expand detail popovers to the 8 domain panels.

Closes #93

## Changes
- **DomainPanel.tsx**: Click-to-expand with friction bar, domain variables grid, coupled domains list, recent events; hover elevation; critical stress pulse; stress trend arrows; chevron indicator
- **SimulationDashboard.tsx**: Pass couplingMatrix and events to DomainPanel
- **index.css**: Hover, expand, critical pulse, detail section styles

## Testing
- `npx tsc --noEmit` ✅
- `npx vitest run` ✅ 95 passed (2 pre-existing authStore failures)