### PR TITLE
feat: add BattlespaceCanvas hover tooltips, legend, and interactivity

### DIFF
--- a/apps/web/src/components/simulation/BattlespaceCanvas.tsx
+++ b/apps/web/src/components/simulation/BattlespaceCanvas.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import {
   ALL_DOMAINS,
   DOMAIN_COLORS,
+  DOMAIN_LABELS,
   DomainLayer,
 } from "../../types/domain";
 import { WorldState } from "../../types/run";
@@ -52,6 +53,20 @@ const DOMAIN_FULL_LABELS: Record<DomainLayer, string> = {
   [DomainLayer.DomesticPoliticalFiscal]: "Domestic",
 };
 
+interface ZoneRect {
+  domain: DomainLayer;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+interface TooltipData {
+  domain: DomainLayer;
+  x: number;
+  y: number;
+}
+
 export default function BattlespaceCanvas({
   worldState,
   previousWorldState,
@@ -59,6 +74,10 @@ export default function BattlespaceCanvas({
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
+  const [showLegend, setShowLegend] = useState(false);
+  const [tooltip, setTooltip] = useState<TooltipData | null>(null);
+  const [hoveredDomain, setHoveredDomain] = useState<DomainLayer | null>(null);
+  const zoneRectsRef = useRef<ZoneRect[]>([]);
 
   // Track container width via ResizeObserver so we re-render on layout
   useEffect(() => {
@@ -70,6 +89,38 @@ export default function BattlespaceCanvas({
     });
     ro.observe(el);
     return () => ro.disconnect();
+  }, []);
+
+  const hitTest = useCallback((clientX: number, clientY: number): DomainLayer | null => {
+    const canvas = canvasRef.current;
+    if (!canvas) return null;
+    const rect = canvas.getBoundingClientRect();
+    const mx = clientX - rect.left;
+    const my = clientY - rect.top;
+    for (const zone of zoneRectsRef.current) {
+      if (mx >= zone.x && mx <= zone.x + zone.w && my >= zone.y && my <= zone.y + zone.h) {
+        return zone.domain;
+      }
+    }
+    return null;
+  }, []);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    const domain = hitTest(e.clientX, e.clientY);
+    setHoveredDomain(domain);
+    if (domain) {
+      const containerRect = containerRef.current?.getBoundingClientRect();
+      if (containerRect) {
+        setTooltip({ domain, x: e.clientX - containerRect.left, y: e.clientY - containerRect.top });
+      }
+    } else {
+      setTooltip(null);
+    }
+  }, [hitTest]);
+
+  const handleMouseLeave = useCallback(() => {
+    setHoveredDomain(null);
+    setTooltip(null);
   }, []);
 
   useEffect(() => {
@@ -89,6 +140,9 @@ export default function BattlespaceCanvas({
 
     const cellW = displayWidth / COLS;
     const cellH = displayHeight / ROWS;
+
+    // Store zone rects for hit-testing (in CSS pixel coords)
+    const newZoneRects: ZoneRect[] = [];
 
     // 1. Background
     ctx.fillStyle = "#0c0c0c";
@@ -138,6 +192,7 @@ export default function BattlespaceCanvas({
         displayWidth / 2,
         displayHeight / 2
       );
+      zoneRectsRef.current = [];
       return;
     }
 
@@ -162,7 +217,11 @@ export default function BattlespaceCanvas({
       const cy = y + cellH / 2;
       zoneCenters[domain] = [cx, cy];
 
+      // Store zone rect for hit-testing
+      newZoneRects.push({ domain, x: zx, y: zy, w: zw, h: zh });
+
       const [dr, dg, db] = hexToRgb(DOMAIN_COLORS[domain]);
+      const isHovered = hoveredDomain === domain;
 
       // Zone fill: domain color with minimum visibility + stress-driven intensity
       const fillAlpha = 0.12 + layer.stress * 0.75;
@@ -177,9 +236,11 @@ export default function BattlespaceCanvas({
       }
 
       // Resilience border — always visible, thickness scales with resilience
-      const borderAlpha = 0.35 + layer.resilience * 0.65;
-      const borderWidth = 1 + layer.resilience * 3;
-      ctx.strokeStyle = `rgba(${dr},${dg},${db},${borderAlpha})`;
+      const borderAlpha = isHovered ? 1 : (0.35 + layer.resilience * 0.65);
+      const borderWidth = isHovered ? (2 + layer.resilience * 3) : (1 + layer.resilience * 3);
+      ctx.strokeStyle = isHovered
+        ? `rgba(255,255,255,0.9)`
+        : `rgba(${dr},${dg},${db},${borderAlpha})`;
       ctx.lineWidth = borderWidth;
       ctx.strokeRect(
         zx + borderWidth / 2,
@@ -187,6 +248,17 @@ export default function BattlespaceCanvas({
         zw - borderWidth,
         zh - borderWidth
       );
+
+      // Hover glow
+      if (isHovered) {
+        ctx.shadowColor = `rgba(${dr},${dg},${db},0.6)`;
+        ctx.shadowBlur = 12;
+        ctx.strokeStyle = `rgba(${dr},${dg},${db},0.4)`;
+        ctx.lineWidth = 1;
+        ctx.strokeRect(zx, zy, zw, zh);
+        ctx.shadowBlur = 0;
+        ctx.shadowColor = "transparent";
+      }
 
       // Activity particles — minimum 2 so zones always look "alive"
       const particleCount = Math.max(2, Math.floor(layer.activity_level * 25));
@@ -251,6 +323,8 @@ export default function BattlespaceCanvas({
       ctx.fillText(`${stressPct}%`, zx + zw - 4, zy + zh - 4);
     });
 
+    zoneRectsRef.current = newZoneRects;
+
     // 3. Coupling lines
     if (coupling_matrix) {
       const drawn = new Set<string>();
@@ -268,8 +342,11 @@ export default function BattlespaceCanvas({
           const b = zoneCenters[domB];
           if (!a || !b) continue;
 
-          ctx.strokeStyle = `rgba(100,110,140,${0.15 + weight * 0.4})`;
-          ctx.lineWidth = 0.5 + weight * 2.5;
+          const isHighlighted = hoveredDomain === domA || hoveredDomain === domB;
+          ctx.strokeStyle = isHighlighted
+            ? `rgba(200,210,240,${0.4 + weight * 0.5})`
+            : `rgba(100,110,140,${0.15 + weight * 0.4})`;
+          ctx.lineWidth = isHighlighted ? (1 + weight * 3) : (0.5 + weight * 2.5);
           ctx.beginPath();
           ctx.moveTo(a[0], a[1]);
           ctx.lineTo(b[0], b[1]);
@@ -277,10 +354,20 @@ export default function BattlespaceCanvas({
         }
       }
     }
-  }, [worldState, previousWorldState, containerWidth]);
+  }, [worldState, previousWorldState, containerWidth, hoveredDomain]);
+
+  const fmtPct = (v: number) => `${(v * 100).toFixed(0)}%`;
+  const layer = tooltip && worldState ? worldState.layers[tooltip.domain] : null;
+  const prevLayer = tooltip && previousWorldState ? previousWorldState.layers[tooltip.domain] : null;
+  const trendArrow = (cur: number, prev?: number) => {
+    if (prev == null) return "→";
+    const d = cur - prev;
+    if (Math.abs(d) < 0.005) return "→";
+    return d > 0 ? "↑" : "↓";
+  };
 
   return (
-    <div ref={containerRef} style={{ width: "100%" }}>
+    <div ref={containerRef} style={{ width: "100%", position: "relative" }}>
       {containerWidth > 0 && (
         <canvas
           ref={canvasRef}
@@ -289,8 +376,72 @@ export default function BattlespaceCanvas({
             imageRendering: "pixelated",
             width: containerWidth,
             height: Math.floor(containerWidth / 2),
+            cursor: hoveredDomain ? "pointer" : "default",
           }}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
         />
+      )}
+
+      {/* Hover tooltip */}
+      {tooltip && layer && (
+        <div
+          className="bc-tooltip"
+          style={{
+            left: Math.min(tooltip.x + 12, containerWidth - 180),
+            top: tooltip.y + 12,
+          }}
+        >
+          <div className="bc-tooltip__title">{DOMAIN_LABELS[tooltip.domain]}</div>
+          <div className="bc-tooltip__row">
+            Stress: <strong>{fmtPct(layer.stress)}</strong> {trendArrow(layer.stress, prevLayer?.stress)}
+          </div>
+          <div className="bc-tooltip__row">
+            Resilience: <strong>{fmtPct(layer.resilience)}</strong> {trendArrow(layer.resilience, prevLayer?.resilience)}
+          </div>
+          <div className="bc-tooltip__row">
+            Activity: <strong>{fmtPct(layer.activity_level)}</strong>
+          </div>
+          <div className="bc-tooltip__row">
+            Friction: <strong>{fmtPct(layer.friction)}</strong>
+          </div>
+        </div>
+      )}
+
+      {/* Legend toggle */}
+      <button
+        className="bc-legend-toggle"
+        onClick={() => setShowLegend((v) => !v)}
+        title="Toggle legend"
+      >
+        {showLegend ? "✕" : "?"}
+      </button>
+
+      {/* Legend overlay */}
+      {showLegend && (
+        <div className="bc-legend">
+          <div className="bc-legend__title">Visual Legend</div>
+          <div className="bc-legend__item">
+            <span className="bc-legend__swatch bc-legend__swatch--fill" />
+            Background intensity = stress level
+          </div>
+          <div className="bc-legend__item">
+            <span className="bc-legend__swatch bc-legend__swatch--particles" />
+            White dots = activity level
+          </div>
+          <div className="bc-legend__item">
+            <span className="bc-legend__swatch bc-legend__swatch--hatch" />
+            Diagonal hatching = friction
+          </div>
+          <div className="bc-legend__item">
+            <span className="bc-legend__swatch bc-legend__swatch--line" />
+            Line thickness = coupling strength
+          </div>
+          <div className="bc-legend__item">
+            <span className="bc-legend__swatch bc-legend__swatch--border" />
+            Border thickness = resilience
+          </div>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -2744,3 +2744,127 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ── BattlespaceCanvas tooltip & legend ── */
+.bc-tooltip {
+  position: absolute;
+  z-index: 20;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid var(--border, #334155);
+  border-radius: var(--radius, 6px);
+  padding: 0.4rem 0.6rem;
+  pointer-events: none;
+  min-width: 140px;
+  font-size: 0.75rem;
+  color: var(--text-primary, #f1f5f9);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+.bc-tooltip__title {
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+  font-size: 0.8rem;
+}
+.bc-tooltip__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  line-height: 1.5;
+  color: var(--text-secondary, #cbd5e1);
+}
+.bc-tooltip__row strong {
+  color: var(--text-primary, #f1f5f9);
+}
+.bc-legend-toggle {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(15, 23, 42, 0.7);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 15;
+  transition: all 0.15s ease;
+}
+.bc-legend-toggle:hover {
+  background: rgba(59, 130, 246, 0.4);
+  border-color: var(--primary, #3b82f6);
+  color: #fff;
+}
+.bc-legend {
+  position: absolute;
+  top: 32px;
+  right: 6px;
+  z-index: 15;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid var(--border, #334155);
+  border-radius: var(--radius, 6px);
+  padding: 0.5rem 0.6rem;
+  font-size: 0.7rem;
+  color: var(--text-secondary, #cbd5e1);
+  min-width: 180px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+.bc-legend__title {
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--text-primary, #f1f5f9);
+  margin-bottom: 0.35rem;
+}
+.bc-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.2rem;
+  line-height: 1.4;
+}
+.bc-legend__swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.bc-legend__swatch--fill {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(59, 130, 246, 0.8));
+}
+.bc-legend__swatch--particles {
+  background: #111;
+  position: relative;
+  overflow: hidden;
+}
+.bc-legend__swatch--particles::after {
+  content: "··";
+  position: absolute;
+  top: 1px;
+  left: 2px;
+  color: white;
+  font-size: 8px;
+  letter-spacing: 1px;
+}
+.bc-legend__swatch--hatch {
+  background: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 2px,
+    rgba(255,255,255,0.15) 2px,
+    rgba(255,255,255,0.15) 3px
+  );
+  background-color: #222;
+}
+.bc-legend__swatch--line {
+  background: transparent;
+  border-bottom: 3px solid rgba(100, 110, 140, 0.6);
+  height: 7px;
+}
+.bc-legend__swatch--border {
+  border: 3px solid rgba(59, 130, 246, 0.7);
+  background: transparent;
+}


### PR DESCRIPTION
## Summary
Adds hover tooltips, a visual legend, and interactive highlighting to the BattlespaceCanvas.

Closes #94

## Changes
- **BattlespaceCanvas.tsx**: Hit-testing via stored zone rects, floating tooltip with domain metrics and trend arrows, cursor change on hover, zone highlight glow, coupling line highlighting for hovered domain, toggleable legend overlay
- **index.css**: Tooltip, legend toggle button, legend overlay, and visual swatch styles

## Testing
- `npx tsc --noEmit` ✅
- `npx vitest run` ✅ 95 passed (2 pre-existing authStore failures)