### PR TITLE
feat: AI opponent reasoning panel with move history and domain heatmap

### DIFF
--- a/apps/web/src/components/ai/AiMovePanel.tsx
+++ b/apps/web/src/components/ai/AiMovePanel.tsx
@@ -1,71 +1,154 @@
-import { AiMoveResult } from "../../types/action";
-import { DOMAIN_LABELS } from "../../types/domain";
+import { useState, useMemo } from "react";
+import { AiMoveResult, ACTION_TYPE_LABELS } from "../../types/action";
+import { DomainLayer, DOMAIN_LABELS, DOMAIN_COLORS } from "../../types/domain";
 
 interface AiMovePanelProps {
-  latestMove: AiMoveResult;
+  moves: AiMoveResult[];
 }
 
-export default function AiMovePanel({ latestMove }: AiMovePanelProps) {
-  const { action, rationale, validation } = latestMove;
+function getConfidenceLevel(confidence?: number): { label: string; color: string } {
+  if (confidence == null) return { label: "N/A", color: "var(--text-muted)" };
+  if (confidence >= 0.7) return { label: "High", color: "#22c55e" };
+  if (confidence >= 0.4) return { label: "Medium", color: "#eab308" };
+  return { label: "Low", color: "#ef4444" };
+}
+
+function narrativeFrame(action: AiMoveResult["action"]): string {
+  const domain = DOMAIN_LABELS[action.target_domain] ?? action.target_domain;
+  const aType = ACTION_TYPE_LABELS[action.action_type] ?? action.action_type;
+  const intensity = action.intensity >= 0.7 ? "major" : action.intensity >= 0.4 ? "moderate" : "minor";
+  return `SIGINT INTERCEPT: Red Commander executed ${intensity} ${aType} targeting ${domain} infrastructure`;
+}
+
+export default function AiMovePanel({ moves }: AiMovePanelProps) {
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [showToolCalls, setShowToolCalls] = useState<number | null>(null);
+
+  // Domain targeting frequency
+  const domainFreq = useMemo(() => {
+    const freq: Record<string, number> = {};
+    for (const m of moves) {
+      const d = m.action.target_domain;
+      freq[d] = (freq[d] ?? 0) + 1;
+    }
+    return Object.entries(freq)
+      .sort((a, b) => b[1] - a[1]);
+  }, [moves]);
+
+  const maxFreq = domainFreq.length > 0 ? domainFreq[0][1] : 1;
+
+  if (moves.length === 0) return null;
 
   return (
-    <div className="ai-move-panel">
-      <div className="ai-move-panel__title">
-        <span
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            background: "var(--accent-purple)",
-            display: "inline-block",
-          }}
-        />
-        AI Move
+    <div className="ai-panel card">
+      <div className="card__title" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <span>
+          <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--accent-purple)", display: "inline-block", marginRight: "0.4rem" }} />
+          Intelligence Report
+        </span>
+        <span className="ai-panel__count">{moves.length} intercept{moves.length !== 1 ? "s" : ""}</span>
       </div>
 
-      <div style={{ marginBottom: "0.5rem" }}>
-        <span
-          style={{
-            fontSize: "0.82rem",
-            fontWeight: 600,
-            color: "var(--text-primary)",
-          }}
-        >
-          {action.action_type}
-        </span>
-        <span
-          style={{
-            fontSize: "0.78rem",
-            color: "var(--text-muted)",
-            marginLeft: "0.5rem",
-          }}
-        >
-          {DOMAIN_LABELS[action.target_domain]} @ {action.intensity.toFixed(1)}
-        </span>
-      </div>
+      {/* Domain targeting heatmap */}
+      {domainFreq.length > 1 && (
+        <div className="ai-panel__heatmap">
+          <div className="ai-panel__heatmap-title">AI Domain Focus</div>
+          <div className="ai-panel__heatmap-bars">
+            {domainFreq.map(([domain, count]) => (
+              <div key={domain} className="ai-panel__heatmap-row">
+                <span className="ai-panel__heatmap-label">{DOMAIN_LABELS[domain as DomainLayer] ?? domain}</span>
+                <div className="ai-panel__heatmap-bar">
+                  <div
+                    className="ai-panel__heatmap-fill"
+                    style={{
+                      width: `${(count / maxFreq) * 100}%`,
+                      background: DOMAIN_COLORS[domain as DomainLayer] ?? "var(--primary)",
+                    }}
+                  />
+                </div>
+                <span className="ai-panel__heatmap-val">{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
-      <div className="ai-move-panel__rationale">{rationale}</div>
+      {/* Move history */}
+      <div className="ai-panel__history">
+        {moves.map((move, idx) => {
+          const { action, rationale, validation, tool_calls } = move;
+          const conf = getConfidenceLevel((move as unknown as Record<string, unknown>).confidence as number | undefined);
+          const isExpanded = expandedIdx === idx;
+          const showTools = showToolCalls === idx;
+          const aLabel = ACTION_TYPE_LABELS[action.action_type] ?? action.action_type;
 
-      <div
-        className="ai-move-panel__validation"
-        style={{
-          color: validation.is_valid
-            ? "var(--accent-green)"
-            : "var(--accent-red)",
-        }}
-      >
-        <span
-          style={{
-            width: 6,
-            height: 6,
-            borderRadius: "50%",
-            background: validation.is_valid
-              ? "var(--accent-green)"
-              : "var(--accent-red)",
-            display: "inline-block",
-          }}
-        />
-        {validation.message}
+          return (
+            <div
+              key={`${action.id}-${idx}`}
+              className={`ai-move ${isExpanded ? "ai-move--expanded" : ""} ${idx === 0 ? "ai-move--latest" : ""}`}
+            >
+              <div
+                className="ai-move__header"
+                onClick={() => setExpandedIdx(isExpanded ? null : idx)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setExpandedIdx(isExpanded ? null : idx); } }}
+              >
+                <span className="ai-move__turn">T{action.turn}</span>
+                <span className="ai-move__type">{aLabel}</span>
+                <span className="ai-move__domain">{DOMAIN_LABELS[action.target_domain]}</span>
+                <span className="ai-move__intensity">@{action.intensity.toFixed(1)}</span>
+                <span className="ai-move__conf" style={{ color: conf.color }}>{conf.label}</span>
+                <span
+                  className="ai-move__valid"
+                  style={{ color: validation.is_valid ? "var(--accent-green)" : "var(--accent-red)" }}
+                >
+                  {validation.is_valid ? "✓" : "✗"}
+                </span>
+                <span className="ai-move__chevron">{isExpanded ? "▾" : "▸"}</span>
+              </div>
+
+              {/* Intel narrative */}
+              {idx === 0 && (
+                <div className="ai-move__narrative">{narrativeFrame(action)}</div>
+              )}
+
+              {isExpanded && (
+                <div className="ai-move__detail" onClick={(e) => e.stopPropagation()}>
+                  <div className="ai-move__rationale">
+                    <strong>Rationale:</strong> {rationale}
+                  </div>
+
+                  <div className="ai-move__validation-msg" style={{ color: validation.is_valid ? "var(--accent-green)" : "var(--accent-red)" }}>
+                    {validation.message}
+                  </div>
+
+                  {tool_calls.length > 0 && (
+                    <div className="ai-move__tools">
+                      <button
+                        className="btn btn--sm btn--ghost"
+                        onClick={() => setShowToolCalls(showTools ? null : idx)}
+                      >
+                        {showTools ? "Hide" : "Show"} Tool Calls ({tool_calls.length})
+                      </button>
+
+                      {showTools && (
+                        <div className="ai-move__tool-timeline">
+                          {tool_calls.map((tc, ti) => (
+                            <div key={ti} className="ai-tool-call">
+                              <span className="ai-tool-call__name">{tc.tool_name}</span>
+                              <span className="ai-tool-call__result">{tc.result.length > 80 ? tc.result.slice(0, 80) + "…" : tc.result}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -329,7 +329,7 @@ export default function SimulationDashboard({
                   />
                 )}
                 <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} />
-                {aiMoves.length > 0 && <AiMovePanel latestMove={aiMoves[0]} />}
+                {aiMoves.length > 0 && <AiMovePanel moves={aiMoves} />}
               </>
             )}
 
@@ -417,7 +417,7 @@ export default function SimulationDashboard({
                 side={side}
               />
             )}
-            {aiMoves.length > 0 && <AiMovePanel latestMove={aiMoves[0]} />}
+            {aiMoves.length > 0 && <AiMovePanel moves={aiMoves} />}
           </div>
         </>
       )}

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -2868,3 +2868,156 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
   border: 3px solid rgba(59, 130, 246, 0.7);
   background: transparent;
 }
+
+/* ── AI Intelligence Panel ── */
+.ai-panel__count {
+  font-size: 0.7rem;
+  color: var(--text-muted, #94a3b8);
+  font-weight: 400;
+}
+.ai-panel__heatmap {
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--border, #334155);
+}
+.ai-panel__heatmap-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #94a3b8);
+  margin-bottom: 0.3rem;
+}
+.ai-panel__heatmap-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.ai-panel__heatmap-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+}
+.ai-panel__heatmap-label {
+  min-width: 4.5rem;
+  color: var(--text-secondary, #cbd5e1);
+  font-size: 0.68rem;
+}
+.ai-panel__heatmap-bar {
+  flex: 1;
+  height: 6px;
+  background: var(--bg-elevated, #1e293b);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.ai-panel__heatmap-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+.ai-panel__heatmap-val {
+  font-size: 0.68rem;
+  color: var(--text-muted, #94a3b8);
+  min-width: 1rem;
+  text-align: right;
+}
+.ai-panel__history {
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 0.25rem 0;
+}
+.ai-move {
+  padding: 0.35rem 0.75rem;
+  border-bottom: 1px solid var(--border, #334155);
+  transition: background 0.15s ease;
+}
+.ai-move:last-child { border-bottom: none; }
+.ai-move:hover { background: rgba(139, 92, 246, 0.06); }
+.ai-move--expanded { background: rgba(139, 92, 246, 0.08); }
+.ai-move--latest { border-left: 2px solid var(--accent-purple, #8b5cf6); }
+.ai-move__header {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  font-size: 0.78rem;
+}
+.ai-move__turn {
+  color: var(--text-muted, #94a3b8);
+  font-weight: 600;
+  font-size: 0.7rem;
+  min-width: 1.5rem;
+}
+.ai-move__type {
+  font-weight: 600;
+  color: var(--text-primary, #f1f5f9);
+}
+.ai-move__domain {
+  color: var(--text-secondary, #cbd5e1);
+  font-size: 0.72rem;
+}
+.ai-move__intensity {
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.7rem;
+}
+.ai-move__conf {
+  font-size: 0.65rem;
+  font-weight: 700;
+  margin-left: auto;
+}
+.ai-move__valid {
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+.ai-move__chevron {
+  font-size: 0.65rem;
+  color: var(--text-muted, #94a3b8);
+}
+.ai-move__narrative {
+  font-size: 0.72rem;
+  color: var(--accent-yellow, #eab308);
+  font-style: italic;
+  margin: 0.2rem 0 0.1rem 1.5rem;
+  opacity: 0.85;
+}
+.ai-move__detail {
+  margin-top: 0.35rem;
+  padding: 0.35rem 0.5rem;
+  background: var(--bg-elevated, #1e293b);
+  border-radius: var(--radius, 6px);
+  font-size: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.ai-move__rationale {
+  color: var(--text-secondary, #cbd5e1);
+  line-height: 1.4;
+}
+.ai-move__validation-msg {
+  font-size: 0.72rem;
+}
+.ai-move__tool-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-top: 0.25rem;
+}
+.ai-tool-call {
+  display: flex;
+  flex-direction: column;
+  padding: 0.2rem 0.4rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  font-size: 0.7rem;
+}
+.ai-tool-call__name {
+  color: var(--primary, #3b82f6);
+  font-weight: 600;
+  font-family: monospace;
+}
+.ai-tool-call__result {
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.65rem;
+  word-break: break-all;
+}


### PR DESCRIPTION
## Changes

- **AiMovePanel.tsx** — Full rewrite: now accepts all AI moves and renders scrollable history with expandable rationale, tool call timeline, validation status, and confidence badges
- **Domain targeting heatmap** — Bar chart showing which domains AI has targeted most (colored by domain)
- **Intel narrative framing** — Latest move shown with SIGINT INTERCEPT style narrative
- **SimulationDashboard.tsx** — Passes full `aiMoves[]` array instead of only `aiMoves[0]`
- **CSS** — 153 lines of new styles for AI panel, heatmap, move history, tool calls

## Testing
- `npx tsc --noEmit` — clean
- `npx vitest run` — 95 pass, 2 pre-existing authStore failures (unrelated)

Closes #96