### PR TITLE
feat: phase transition timeline and Ψ escalation history tracker

### DIFF
--- a/apps/web/src/components/simulation/DomainStressChart.tsx
+++ b/apps/web/src/components/simulation/DomainStressChart.tsx
@@ -6,20 +6,30 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  ReferenceLine,
 } from "recharts";
 import { DomainLayer, DOMAIN_LABELS, DOMAIN_COLORS, ALL_DOMAINS } from "../../types/domain";
+import { Phase, PHASE_THRESHOLDS, PHASE_LABELS, PHASE_ORDER } from "../../types/phase";
 
 interface StressHistoryEntry {
   turn: number;
   values: Record<DomainLayer, number>;
 }
 
+interface PsiHistoryEntry {
+  turn: number;
+  psi: number;
+  phase: Phase;
+}
+
 interface DomainStressChartProps {
   stressHistory: StressHistoryEntry[];
+  psiHistory?: PsiHistoryEntry[];
 }
 
 export default function DomainStressChart({
   stressHistory,
+  psiHistory,
 }: DomainStressChartProps) {
   if (stressHistory.length === 0) {
     return (
@@ -32,14 +42,23 @@ export default function DomainStressChart({
     );
   }
 
+  // Merge stress and Ψ data by turn
+  const psiByTurn = new Map<number, number>();
+  if (psiHistory) {
+    for (const entry of psiHistory) {
+      psiByTurn.set(entry.turn, entry.psi);
+    }
+  }
+
   const chartData = stressHistory.map((entry) => ({
     turn: entry.turn,
     ...entry.values,
+    psi: psiByTurn.get(entry.turn) ?? null,
   }));
 
   return (
     <div className="card">
-      <div className="card__title">Domain Stress Over Time</div>
+      <div className="card__title">Domain Stress &amp; Ψ Over Time</div>
       <div style={{ width: "100%", height: 220 }}>
         <ResponsiveContainer>
           <LineChart
@@ -67,11 +86,28 @@ export default function DomainStressChart({
                 fontSize: "0.78rem",
               }}
               labelFormatter={(label) => `Turn ${label}`}
-              formatter={(value: number, name: string) => [
-                `${(value * 100).toFixed(1)}%`,
-                DOMAIN_LABELS[name as DomainLayer] ?? name,
-              ]}
+              formatter={(value: number, name: string) => {
+                if (name === "psi") return [`Ψ ${value.toFixed(3)}`, "Order Parameter"];
+                return [
+                  `${(value * 100).toFixed(1)}%`,
+                  DOMAIN_LABELS[name as DomainLayer] ?? name,
+                ];
+              }}
             />
+            {/* Phase threshold reference lines */}
+            {PHASE_ORDER.slice(0, -1).map((p) => {
+              const threshold = PHASE_THRESHOLDS[p];
+              if (threshold === undefined) return null;
+              return (
+                <ReferenceLine
+                  key={p}
+                  y={threshold}
+                  stroke={`${PHASE_LABELS[p].includes("0") ? "#22c55e" : "#ef4444"}33`}
+                  strokeDasharray="2 4"
+                  label={false}
+                />
+              );
+            })}
             {ALL_DOMAINS.map((domain) => (
               <Line
                 key={domain}
@@ -83,6 +119,17 @@ export default function DomainStressChart({
                 name={domain}
               />
             ))}
+            {/* Ψ line */}
+            <Line
+              type="monotone"
+              dataKey="psi"
+              stroke="#a855f7"
+              strokeWidth={2.5}
+              strokeDasharray="6 3"
+              dot={{ r: 3, fill: "#a855f7" }}
+              name="psi"
+              connectNulls
+            />
           </LineChart>
         </ResponsiveContainer>
       </div>

--- a/apps/web/src/components/simulation/PhaseIndicator.tsx
+++ b/apps/web/src/components/simulation/PhaseIndicator.tsx
@@ -9,14 +9,40 @@ import { formatOrderParameter } from "../../utils/formatters";
 import { PHASE_DESCRIPTIONS } from "../../data/glossary";
 import InfoTooltip from "../common/InfoTooltip";
 
+interface PhaseTransition {
+  turn: number;
+  phase: Phase;
+}
+
 interface PhaseIndicatorProps {
   phase: Phase;
   orderParameter: number;
+  phaseHistory?: PhaseTransition[];
 }
+
+// Phase Ψ range boundaries (start of each phase)
+const PHASE_STARTS: Record<Phase, number> = {
+  [Phase.CompetitiveNormality]: 0,
+  [Phase.HybridCoercion]: 0.15,
+  [Phase.AcutePolycrisis]: 0.30,
+  [Phase.WarTransition]: 0.50,
+  [Phase.OvertInterstateWar]: 0.70,
+  [Phase.GeneralizedBlocWar]: 0.85,
+};
+
+const SHORT_LABELS: Record<Phase, string> = {
+  [Phase.CompetitiveNormality]: "P0",
+  [Phase.HybridCoercion]: "P1",
+  [Phase.AcutePolycrisis]: "P2",
+  [Phase.WarTransition]: "P3",
+  [Phase.OvertInterstateWar]: "P4",
+  [Phase.GeneralizedBlocWar]: "P5",
+};
 
 export default function PhaseIndicator({
   phase,
   orderParameter,
+  phaseHistory,
 }: PhaseIndicatorProps) {
   const color = PHASE_COLORS[phase];
   const phaseIndex = PHASE_ORDER.indexOf(phase);
@@ -31,6 +57,14 @@ export default function PhaseIndicator({
       : `${PHASE_LABELS[p]} (final phase)`;
   });
 
+  // Next threshold info
+  const nextPhase = PHASE_ORDER[phaseIndex + 1];
+  const nextThreshold = currentThreshold;
+  const distToNext = nextThreshold !== undefined ? nextThreshold - orderParameter : null;
+
+  // Ψ position on the 0–1 bar (clamped)
+  const psiPct = Math.min(Math.max(orderParameter, 0), 1) * 100;
+
   return (
     <div className="phase-indicator" style={{ borderColor: color }}>
       <div
@@ -39,7 +73,7 @@ export default function PhaseIndicator({
         }`}
         style={{ backgroundColor: color }}
       />
-      <div>
+      <div style={{ flex: 1 }}>
         <div className="phase-indicator__name" style={{ color }}>
           <span className="phase-indicator__label">
             {PHASE_LABELS[phase]}
@@ -73,6 +107,47 @@ export default function PhaseIndicator({
               -- TRANSITION WARNING
             </span>
           )}
+          {distToNext !== null && distToNext > 0.05 && nextPhase && (
+            <span className="phase-indicator__dist">
+              {distToNext.toFixed(2)} to {SHORT_LABELS[nextPhase]}
+            </span>
+          )}
+        </div>
+
+        {/* Escalation timeline bar */}
+        <div className="esc-timeline">
+          {PHASE_ORDER.map((p, i) => {
+            const start = PHASE_STARTS[p];
+            const end = i < PHASE_ORDER.length - 1 ? PHASE_STARTS[PHASE_ORDER[i + 1]] : 1;
+            const widthPct = (end - start) * 100;
+            const isCurrent = p === phase;
+            const isPast = PHASE_ORDER.indexOf(p) < phaseIndex;
+
+            // Find transition marker for this phase
+            const transition = phaseHistory?.find((h) => h.phase === p && PHASE_ORDER.indexOf(p) > 0);
+
+            return (
+              <div
+                key={p}
+                className={`esc-timeline__seg ${isCurrent ? "esc-timeline__seg--active" : ""} ${isPast ? "esc-timeline__seg--past" : ""}`}
+                style={{ width: `${widthPct}%`, background: isPast || isCurrent ? PHASE_COLORS[p] : undefined }}
+                title={`${PHASE_LABELS[p]} (Ψ ${start.toFixed(2)}–${end.toFixed(2)})`}
+              >
+                <span className="esc-timeline__label">{SHORT_LABELS[p]}</span>
+                {transition && (
+                  <span className="esc-timeline__marker" title={`Transitioned T${transition.turn}`}>
+                    T{transition.turn}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+          {/* Ψ position marker */}
+          <div
+            className="esc-timeline__cursor"
+            style={{ left: `${psiPct}%` }}
+            title={`Ψ = ${orderParameter.toFixed(3)}`}
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -66,12 +66,24 @@ export default function SimulationDashboard({
   const events = useRunStore((s) => s.events);
   const legalActions = useRunStore((s) => s.legalActions);
   const stressHistory = useRunStore((s) => s.stressHistory);
+  const psiHistory = useRunStore((s) => s.psiHistory);
   const aiMoves = useRunStore((s) => s.aiMoves);
   const isAdvancingTurn = useRunStore((s) => s.isAdvancingTurn);
   const run = useRunStore((s) => s.run);
 
   const { submitAction, isSubmitting, advanceTurn, isAdvancing, advanceError } =
     useActions(runId);
+
+  // Derive phase transitions from Ψ history
+  const phaseTransitions = useMemo(() => {
+    const transitions: { turn: number; phase: Phase }[] = [];
+    for (let i = 1; i < psiHistory.length; i++) {
+      if (psiHistory[i].phase !== psiHistory[i - 1].phase) {
+        transitions.push({ turn: psiHistory[i].turn, phase: psiHistory[i].phase });
+      }
+    }
+    return transitions;
+  }, [psiHistory]);
 
   // Compute player resources for turn confirmation dialog
   const playerResources = (() => {
@@ -237,6 +249,7 @@ export default function SimulationDashboard({
           <PhaseIndicator
             phase={currentPhase}
             orderParameter={orderParameter}
+            phaseHistory={phaseTransitions}
           />
           <div className="sim-top__links">
             <Link to="/tutorial">↩ Return to tutorial</Link>
@@ -309,7 +322,7 @@ export default function SimulationDashboard({
                   previousOrderParameter={previousOrderParameter}
                   previousWorldState={previousWorldState}
                 />
-                <DomainStressChart stressHistory={stressHistory} />
+                <DomainStressChart stressHistory={stressHistory} psiHistory={psiHistory} />
               </>
             )}
 
@@ -383,7 +396,7 @@ export default function SimulationDashboard({
               previousOrderParameter={previousOrderParameter}
               previousWorldState={previousWorldState}
             />
-            <DomainStressChart stressHistory={stressHistory} />
+            <DomainStressChart stressHistory={stressHistory} psiHistory={psiHistory} />
             <div style={{ textAlign: "center", margin: "0.3rem 0", display: "flex", gap: "0.5rem", justifyContent: "center" }}>
               <button
                 className="btn btn--sm btn--ghost"

--- a/apps/web/src/hooks/useActions.ts
+++ b/apps/web/src/hooks/useActions.ts
@@ -59,6 +59,11 @@ export function useActions(runId: string | undefined) {
           result.world_state.layers as Record<DomainLayer, LayerState>
         );
       }
+      store().addPsiSnapshot(
+        result.turn,
+        result.world_state?.order_parameter ?? store().orderParameter,
+        result.world_state?.phase ?? store().currentPhase,
+      );
 
       // Create synthetic events from narrative data
       const syntheticEvents: TurnEvent[] = [];

--- a/apps/web/src/hooks/useRunState.ts
+++ b/apps/web/src/hooks/useRunState.ts
@@ -6,7 +6,7 @@ import { useAuthStore } from "../stores/authStore";
 import { DomainLayer, LayerState } from "../types/domain";
 
 export function useRunState(runId: string | undefined) {
-  const { setRun, setLegalActions, addStressSnapshot, run } = useRunStore();
+  const { setRun, setLegalActions, addStressSnapshot, addPsiSnapshot, run } = useRunStore();
   const user = useAuthStore((s) => s.user);
 
   const runQuery = useQuery({
@@ -24,9 +24,14 @@ export function useRunState(runId: string | undefined) {
           runQuery.data.current_turn,
           runQuery.data.world_state.layers as Record<DomainLayer, LayerState>
         );
+        addPsiSnapshot(
+          runQuery.data.current_turn,
+          runQuery.data.order_parameter ?? 0,
+          runQuery.data.current_phase,
+        );
       }
     }
-  }, [runQuery.data, setRun, addStressSnapshot]);
+  }, [runQuery.data, setRun, addStressSnapshot, addPsiSnapshot]);
 
   const myRole = run?.participants.find((p) => p.user_id === user?.id)?.role;
   const side = myRole === "red_commander" ? "red" : "blue";

--- a/apps/web/src/hooks/useWebSocket.ts
+++ b/apps/web/src/hooks/useWebSocket.ts
@@ -74,6 +74,7 @@ export function useWebSocket(runId: string | undefined) {
           msg.turn,
           msg.world_state.layers as Record<DomainLayer, LayerState>
         );
+        rs().addPsiSnapshot(msg.turn, msg.order_parameter, msg.phase);
       })
     );
 
@@ -85,6 +86,11 @@ export function useWebSocket(runId: string | undefined) {
         rs().addStressSnapshot(
           msg.turn,
           msg.world_state.layers as Record<DomainLayer, LayerState>
+        );
+        rs().addPsiSnapshot(
+          msg.turn,
+          msg.world_state.order_parameter ?? rs().orderParameter,
+          msg.world_state.phase ?? rs().currentPhase,
         );
       })
     );

--- a/apps/web/src/stores/runStore.ts
+++ b/apps/web/src/stores/runStore.ts
@@ -9,6 +9,12 @@ interface StressHistoryEntry {
   values: Record<DomainLayer, number>;
 }
 
+interface PsiHistoryEntry {
+  turn: number;
+  psi: number;
+  phase: Phase;
+}
+
 interface RunState {
   run: RunRead | null;
   worldState: WorldState | null;
@@ -21,6 +27,7 @@ interface RunState {
   legalActions: LegalAction[];
   participants: RunParticipant[];
   stressHistory: StressHistoryEntry[];
+  psiHistory: PsiHistoryEntry[];
   aiMoves: AiMoveResult[];
   isAdvancingTurn: boolean;
 
@@ -37,6 +44,7 @@ interface RunState {
   addParticipant: (participant: RunParticipant) => void;
   removeParticipant: (userId: string) => void;
   addStressSnapshot: (turn: number, layers: Record<DomainLayer, LayerState>) => void;
+  addPsiSnapshot: (turn: number, psi: number, phase: Phase) => void;
   addAiMove: (move: AiMoveResult) => void;
   setIsAdvancingTurn: (val: boolean) => void;
   reset: () => void;
@@ -54,6 +62,7 @@ const initialState = {
   legalActions: [] as LegalAction[],
   participants: [] as RunParticipant[],
   stressHistory: [] as StressHistoryEntry[],
+  psiHistory: [] as PsiHistoryEntry[],
   aiMoves: [] as AiMoveResult[],
   isAdvancingTurn: false,
 };
@@ -139,6 +148,11 @@ export const useRunStore = create<RunState>()((set) => ({
         stressHistory: [...state.stressHistory, { turn, values }].slice(-50),
       };
     }),
+
+  addPsiSnapshot: (turn, psi, phase) =>
+    set((state) => ({
+      psiHistory: [...state.psiHistory, { turn, psi, phase }].slice(-50),
+    })),
 
   addAiMove: (move) =>
     set((state) => ({

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -3021,3 +3021,62 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
   font-size: 0.65rem;
   word-break: break-all;
 }
+
+/* ── Escalation Timeline ── */
+.esc-timeline {
+  display: flex;
+  position: relative;
+  height: 16px;
+  margin-top: 0.4rem;
+  border-radius: 3px;
+  overflow: visible;
+  background: var(--bg-elevated, #1e293b);
+  border: 1px solid var(--border, #334155);
+}
+.esc-timeline__seg {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  opacity: 0.35;
+  transition: opacity 0.2s ease;
+  border-right: 1px solid rgba(255,255,255,0.1);
+}
+.esc-timeline__seg:last-child { border-right: none; }
+.esc-timeline__seg--past { opacity: 0.6; }
+.esc-timeline__seg--active { opacity: 1; }
+.esc-timeline__label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: rgba(255,255,255,0.85);
+  text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+  pointer-events: none;
+  user-select: none;
+}
+.esc-timeline__marker {
+  position: absolute;
+  top: -14px;
+  left: 1px;
+  font-size: 0.55rem;
+  color: var(--text-muted, #94a3b8);
+  white-space: nowrap;
+}
+.esc-timeline__cursor {
+  position: absolute;
+  top: -3px;
+  width: 3px;
+  height: 22px;
+  background: #fff;
+  border-radius: 2px;
+  box-shadow: 0 0 6px rgba(168,85,247,0.8);
+  transform: translateX(-1px);
+  transition: left 0.3s ease;
+  z-index: 2;
+  pointer-events: none;
+}
+.phase-indicator__dist {
+  font-size: 0.72rem;
+  color: var(--text-muted, #94a3b8);
+  margin-left: 0.5rem;
+}


### PR DESCRIPTION
## Changes

- **runStore.ts** — New `psiHistory` array tracking Ψ value + phase per turn (capped at 50 entries)
- **PhaseIndicator.tsx** — Escalation timeline bar showing all 6 phases with proportional Ψ-range segments, current Ψ cursor (animated glow), phase transition turn markers, and distance-to-next-threshold display
- **DomainStressChart.tsx** — Added purple dashed Ψ line overlaid on domain stress chart with phase threshold reference lines
- **useActions/useRunState/useWebSocket** — Added `addPsiSnapshot` calls alongside existing stress snapshots
- **SimulationDashboard.tsx** — Derives `phaseTransitions` from Ψ history and passes to PhaseIndicator and DomainStressChart
- **CSS** — 59 lines for escalation timeline styling

## Testing
- `npx tsc --noEmit` — clean
- `npx vitest run` — 95 pass, 2 pre-existing authStore failures (unrelated)

Closes #99