### PR TITLE
fix: reduce repeated border/chrome noise across simulation cards

### DIFF
--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -449,9 +449,14 @@ input, select, textarea, button {
 /* Domain panel */
 .domain-panel {
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid transparent;
   border-radius: var(--radius);
   padding: 0.85rem 1rem;
+  transition: border-color 0.15s ease;
+}
+
+.domain-panel:hover {
+  border-color: var(--border);
 }
 
 .domain-panel__header {
@@ -692,7 +697,7 @@ input[type="range"] {
 
 .metric-card {
   background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  border: none;
   border-radius: var(--radius);
   padding: 0.75rem;
   text-align: center;
@@ -978,7 +983,7 @@ input[type="range"] {
   justify-content: center;
   padding: 0.6rem;
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: none;
   border-radius: var(--radius);
   flex-shrink: 0;
 }
@@ -988,7 +993,7 @@ input[type="range"] {
   align-items: center;
   gap: 0.4rem;
   padding: 0.5rem 0.85rem;
-  border: 1px solid var(--border);
+  border: 1px solid transparent;
   border-radius: var(--radius);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
@@ -1202,7 +1207,7 @@ input[type="range"] {
 /* AI panels */
 .ai-move-panel {
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid transparent;
   border-radius: var(--radius);
   padding: 1rem;
 }


### PR DESCRIPTION
## Changes - Remove borders from metric cards (use background-only differentiation) - Make domain panel borders transparent, shown only on hover - Remove border from AI move panel (nested context sufficient) - Remove border from domain action bar - Make domain action buttons borderless by default  ## Testing CSS-only changes — no TypeScript or logic modifications.  Closes #131