### PR TITLE
feat: add section headers and grouping inside simulation info rail

### DIFF
--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -413,35 +413,49 @@ export default function SimulationDashboard({
 
           {/* RIGHT: Metrics, Chart, Events */}
           <div className="sim-panel--info">
-            <MetricsOverview
-              orderParameter={orderParameter}
-              phase={currentPhase}
-              turn={currentTurn}
-              eventCount={events.length}
-              worldState={worldState}
-              side={side}
-              previousOrderParameter={previousOrderParameter}
-              previousWorldState={previousWorldState}
-            />
-            {aiMoves.length > 0 && <AiMovePanel moves={aiMoves} />}
-            <DomainStressChart stressHistory={stressHistory} psiHistory={psiHistory} />
-            <div style={{ display: "flex", gap: "0.5rem", justifyContent: "center", flexShrink: 0 }}>
-              <button
-                className="btn btn--sm btn--ghost"
-                onClick={() => setShowCouplingGraph(true)}
-                title="View domain coupling map (C)"
-              >
-                🔗 View Couplings
-              </button>
-              <button
-                className="btn btn--sm btn--ghost"
-                onClick={() => setShowGlossary(true)}
-                title="Open game glossary (G)"
-              >
-                📖 Glossary
-              </button>
+            <div className="info-section">
+              <h3 className="info-section__heading">Status</h3>
+              <MetricsOverview
+                orderParameter={orderParameter}
+                phase={currentPhase}
+                turn={currentTurn}
+                eventCount={events.length}
+                worldState={worldState}
+                side={side}
+                previousOrderParameter={previousOrderParameter}
+                previousWorldState={previousWorldState}
+              />
             </div>
-            <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} />
+            {aiMoves.length > 0 && (
+              <div className="info-section">
+                <h3 className="info-section__heading">Opponent Activity</h3>
+                <AiMovePanel moves={aiMoves} />
+              </div>
+            )}
+            <div className="info-section">
+              <h3 className="info-section__heading">Analytics</h3>
+              <DomainStressChart stressHistory={stressHistory} psiHistory={psiHistory} />
+              <div style={{ display: "flex", gap: "0.5rem", justifyContent: "center", flexShrink: 0 }}>
+                <button
+                  className="btn btn--sm btn--ghost"
+                  onClick={() => setShowCouplingGraph(true)}
+                  title="View domain coupling map (C)"
+                >
+                  🔗 View Couplings
+                </button>
+                <button
+                  className="btn btn--sm btn--ghost"
+                  onClick={() => setShowGlossary(true)}
+                  title="Open game glossary (G)"
+                >
+                  📖 Glossary
+                </button>
+              </div>
+            </div>
+            <div className="info-section">
+              <h3 className="info-section__heading">Events</h3>
+              <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} />
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -906,6 +906,24 @@ input[type="range"] {
   overflow-y: auto;
 }
 
+/* Info rail section grouping */
+.info-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.info-section__heading {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  margin: 0;
+}
+
 .sim-layout--tablet {
   grid-template-columns: 1fr;
   grid-template-rows: auto 1fr;


### PR DESCRIPTION
## Changes - Wrap info rail components in named sections: Status, Opponent Activity, Analytics, Events - Add subtle section headings with border separators - Sections group related widgets for faster visual scanning  ## Testing CSS + JSX layout changes only.  Closes #120