### PR TITLE
feat: move trend analytics behind progressive disclosure

### DIFF
--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -135,6 +135,7 @@ export default function SimulationDashboard({
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showCouplingGraph, setShowCouplingGraph] = useState(false);
   const [showGlossary, setShowGlossary] = useState(false);
+  const [analyticsExpanded, setAnalyticsExpanded] = useState(false);
   const [actionModalDomain, setActionModalDomain] = useState<DomainLayer | null>(null);
   const prevWorldStateRef = useRef<WorldState | null>(null);
   const isMountedRef = useRef(true);
@@ -437,24 +438,36 @@ export default function SimulationDashboard({
               <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} />
             </div>
             <div className="info-section">
-              <h3 className="info-section__heading">Analytics</h3>
-              <DomainStressChart stressHistory={stressHistory} psiHistory={psiHistory} />
-              <div style={{ display: "flex", gap: "0.5rem", justifyContent: "center", flexShrink: 0 }}>
-                <button
-                  className="btn btn--sm btn--ghost"
-                  onClick={() => setShowCouplingGraph(true)}
-                  title="View domain coupling map (C)"
-                >
-                  🔗 View Couplings
-                </button>
-                <button
-                  className="btn btn--sm btn--ghost"
-                  onClick={() => setShowGlossary(true)}
-                  title="Open game glossary (G)"
-                >
-                  📖 Glossary
-                </button>
-              </div>
+              <button
+                type="button"
+                className="info-section__heading info-section__heading--toggle"
+                onClick={() => setAnalyticsExpanded((v) => !v)}
+                aria-expanded={analyticsExpanded}
+              >
+                <span>Analytics</span>
+                <span className="info-section__chevron">{analyticsExpanded ? "▾" : "▸"}</span>
+              </button>
+              {analyticsExpanded && (
+                <>
+                  <DomainStressChart stressHistory={stressHistory} psiHistory={psiHistory} />
+                  <div style={{ display: "flex", gap: "0.5rem", justifyContent: "center", flexShrink: 0 }}>
+                    <button
+                      className="btn btn--sm btn--ghost"
+                      onClick={() => setShowCouplingGraph(true)}
+                      title="View domain coupling map (C)"
+                    >
+                      🔗 View Couplings
+                    </button>
+                    <button
+                      className="btn btn--sm btn--ghost"
+                      onClick={() => setShowGlossary(true)}
+                      title="Open game glossary (G)"
+                    >
+                      📖 Glossary
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -924,6 +924,27 @@ input[type="range"] {
   margin: 0;
 }
 
+.info-section__heading--toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.info-section__heading--toggle:hover {
+  color: var(--text-secondary);
+}
+
+.info-section__chevron {
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
 .sim-layout--tablet {
   grid-template-columns: 1fr;
   grid-template-rows: auto 1fr;


### PR DESCRIPTION
## Changes - Analytics section is now collapsible with a toggle heading - Default state is collapsed, favoring current-turn event surfaces - Chevron indicator shows expand/collapse state - Click heading to toggle chart and coupling/glossary buttons  ## Testing Layout + state changes only.  Closes #122