### PR TITLE
feat: add chart legend with per-series visibility toggles

### DIFF
--- a/apps/web/src/components/simulation/DomainStressChart.tsx
+++ b/apps/web/src/components/simulation/DomainStressChart.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   LineChart,
   Line,
@@ -31,6 +32,17 @@ export default function DomainStressChart({
   stressHistory,
   psiHistory,
 }: DomainStressChartProps) {
+  const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(new Set());
+
+  const toggleSeries = (key: string) => {
+    setHiddenSeries((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
   if (stressHistory.length === 0) {
     return (
       <div className="card">
@@ -117,6 +129,7 @@ export default function DomainStressChart({
                 strokeWidth={1.5}
                 dot={false}
                 name={domain}
+                hide={hiddenSeries.has(domain)}
               />
             ))}
             {/* Ψ line */}
@@ -129,9 +142,37 @@ export default function DomainStressChart({
               dot={{ r: 3, fill: "#a855f7" }}
               name="psi"
               connectNulls
+              hide={hiddenSeries.has("psi")}
             />
           </LineChart>
         </ResponsiveContainer>
+      </div>
+      <div className="chart-legend">
+        {ALL_DOMAINS.map((domain) => (
+          <button
+            key={domain}
+            type="button"
+            className={`chart-legend__item${hiddenSeries.has(domain) ? " chart-legend__item--hidden" : ""}`}
+            onClick={() => toggleSeries(domain)}
+          >
+            <span
+              className="chart-legend__swatch"
+              style={{ background: DOMAIN_COLORS[domain] }}
+            />
+            {DOMAIN_LABELS[domain]}
+          </button>
+        ))}
+        <button
+          type="button"
+          className={`chart-legend__item${hiddenSeries.has("psi") ? " chart-legend__item--hidden" : ""}`}
+          onClick={() => toggleSeries("psi")}
+        >
+          <span
+            className="chart-legend__swatch chart-legend__swatch--dashed"
+            style={{ background: "#a855f7" }}
+          />
+          Ψ
+        </button>
       </div>
     </div>
   );

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -260,6 +260,53 @@ input, select, textarea, button {
   line-height: 1.5;
 }
 
+/* Chart legend */
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.5rem;
+  padding: 0.35rem 0.25rem 0;
+}
+
+.chart-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.65rem;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.15rem 0.3rem;
+  border-radius: 3px;
+  transition: opacity 0.15s;
+}
+
+.chart-legend__item:hover {
+  background: var(--bg-tertiary);
+}
+
+.chart-legend__item--hidden {
+  opacity: 0.35;
+  text-decoration: line-through;
+}
+
+.chart-legend__swatch {
+  display: inline-block;
+  width: 10px;
+  height: 3px;
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+
+.chart-legend__swatch--dashed {
+  background: repeating-linear-gradient(
+    90deg,
+    currentColor 0 4px,
+    transparent 4px 6px
+  ) !important;
+}
+
 /* Buttons */
 .btn {
   display: inline-flex;


### PR DESCRIPTION
## Changes
- Interactive legend below the stress chart with color swatches
- Click any series label to toggle visibility
- Hidden series show strikethrough + reduced opacity
- Legend responsive with flex-wrap

## Testing
Component state + CSS only.

Closes #128