### PR TITLE
feat: show persistent submitted-actions summary before End Turn

### DIFF
--- a/apps/web/src/components/simulation/TurnControls.tsx
+++ b/apps/web/src/components/simulation/TurnControls.tsx
@@ -100,17 +100,45 @@ export default function TurnControls({
     }
   }, [showDialog]);
 
+  // Compute affected domains
+  const affectedDomains = new Set<string>();
+  let totalCost = 0;
+  for (const evt of submittedActions) {
+    if (evt.domain) affectedDomains.add(DOMAIN_LABELS[evt.domain as DomainLayer] ?? evt.domain);
+    const costMatch = evt.description.match(/(\d+)\s*RP/i);
+    if (costMatch) totalCost += parseInt(costMatch[1], 10);
+  }
+
   return (
     <div className="turn-controls">
       <span className="turn-controls__counter">Turn {turn}</span>
       {!isObserver && (
-        <button
-          className="btn btn--primary"
-          onClick={handleEndTurnClick}
-          disabled={isAdvancing}
-        >
-          {isAdvancing ? "Advancing..." : "End Turn"}
-        </button>
+        <>
+          <div className="turn-preflight">
+            {submittedActions.length === 0 ? (
+              <span className="turn-preflight__empty">No actions queued</span>
+            ) : (
+              <span className="turn-preflight__summary">
+                {submittedActions.length} action{submittedActions.length !== 1 ? "s" : ""}
+                {affectedDomains.size > 0 && (
+                  <span className="turn-preflight__domains">
+                    {" · "}{[...affectedDomains].join(", ")}
+                  </span>
+                )}
+                {totalCost > 0 && (
+                  <span className="turn-preflight__cost"> · {totalCost} RP</span>
+                )}
+              </span>
+            )}
+          </div>
+          <button
+            className="btn btn--primary"
+            onClick={handleEndTurnClick}
+            disabled={isAdvancing}
+          >
+            {isAdvancing ? "Advancing..." : "End Turn"}
+          </button>
+        </>
       )}
 
       <Dialog

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -1199,6 +1199,29 @@ input[type="range"] {
   color: var(--text-secondary);
 }
 
+/* Preflight summary */
+.turn-preflight {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.turn-preflight__empty {
+  color: var(--warning, #f59e0b);
+  font-style: italic;
+}
+
+.turn-preflight__summary {
+  color: var(--text-secondary);
+}
+
+.turn-preflight__domains {
+  color: var(--text-muted);
+}
+
+.turn-preflight__cost {
+  color: var(--accent-blue);
+}
+
 .advisor-dialog__actions {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Changes - Compact preflight summary between Turn counter and End Turn button - Shows action count, affected domain names, and total RP cost - Italic warning when no actions queued - Remains compact and does not overpower the CTA  ## Testing CSS + JSX only.  Closes #130