### PR TITLE
feat: clarify simulation header hierarchy and reduce competing actions

### DIFF
--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -136,6 +136,7 @@ export default function SimulationDashboard({
   const [showCouplingGraph, setShowCouplingGraph] = useState(false);
   const [showGlossary, setShowGlossary] = useState(false);
   const [analyticsExpanded, setAnalyticsExpanded] = useState(false);
+  const [showUtilMenu, setShowUtilMenu] = useState(false);
   const [actionModalDomain, setActionModalDomain] = useState<DomainLayer | null>(null);
   const prevWorldStateRef = useRef<WorldState | null>(null);
   const isMountedRef = useRef(true);
@@ -274,42 +275,13 @@ export default function SimulationDashboard({
   return (
     <div className={layoutClasses}>
       <div className="sim-layout__top">
-        <div className="sim-top__left">
+        <div className="sim-top__primary">
           <PhaseIndicator
             phase={currentPhase}
             orderParameter={orderParameter}
             phaseHistory={phaseTransitions}
             side={myRole !== "observer" ? side : undefined}
           />
-          <div className="sim-top__links">
-            <Link to="/tutorial">↩ Return to tutorial</Link>
-            <Link to="/help">Help & docs</Link>
-            <button
-              className="btn btn--sm"
-              type="button"
-              onClick={() => setShowShortcuts(true)}
-              aria-keyshortcuts="?"
-            >
-              ? Shortcuts
-            </button>
-            {run?.scenario_id && (
-              <ScenarioBriefing
-                scenarioId={run.scenario_id}
-                scenarioName={run.scenario_name ?? run.name}
-                side={side}
-              />
-            )}
-          </div>
-        </div>
-        <div className="sim-top__right">
-          {myRole && myRole !== "observer" && (
-            <AdvisorDialog
-              runId={runId}
-              roleId={myRole}
-              canApply
-              onApplySuggestion={handleApplyAdvisorSuggestion}
-            />
-          )}
           <TurnControls
             turn={currentTurn}
             isAdvancing={isAdvancing || isAdvancingTurn}
@@ -318,6 +290,47 @@ export default function SimulationDashboard({
             currentTurnEvents={events}
             resources={playerResources}
           />
+        </div>
+        <div className="sim-top__secondary">
+          {myRole && myRole !== "observer" && (
+            <AdvisorDialog
+              runId={runId}
+              roleId={myRole}
+              canApply
+              onApplySuggestion={handleApplyAdvisorSuggestion}
+            />
+          )}
+          <div className="sim-util-menu">
+            <button
+              type="button"
+              className="btn btn--sm btn--ghost sim-util-menu__trigger"
+              onClick={() => setShowUtilMenu((v) => !v)}
+              aria-expanded={showUtilMenu}
+              aria-label="Utilities menu"
+            >
+              ⋯
+            </button>
+            {showUtilMenu && (
+              <div className="sim-util-menu__dropdown" onClick={() => setShowUtilMenu(false)}>
+                <Link to="/tutorial" className="sim-util-menu__item">↩ Tutorial</Link>
+                <Link to="/help" className="sim-util-menu__item">Help &amp; docs</Link>
+                <button
+                  className="sim-util-menu__item"
+                  type="button"
+                  onClick={() => setShowShortcuts(true)}
+                >
+                  ? Shortcuts
+                </button>
+                {run?.scenario_id && (
+                  <ScenarioBriefing
+                    scenarioId={run.scenario_id}
+                    scenarioName={run.scenario_name ?? run.name}
+                    side={side}
+                  />
+                )}
+              </div>
+            )}
+          </div>
         </div>
         {advanceErrorMessage && (
           <div className="error-container">

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -1158,8 +1158,8 @@ input[type="range"] {
   text-align: center;
 }
 
-.sim-top__left,
-.sim-top__right {
+.sim-top__primary,
+.sim-top__secondary {
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -1168,6 +1168,49 @@ input[type="range"] {
 
 .sim-layout__top > .error-container {
   flex-basis: 100%;
+}
+
+/* Utility dropdown menu */
+.sim-util-menu {
+  position: relative;
+}
+
+.sim-util-menu__trigger {
+  font-size: 1.1rem;
+  letter-spacing: 0.15em;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+}
+
+.sim-util-menu__dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 20;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.25rem 0;
+  min-width: 10rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.sim-util-menu__item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.sim-util-menu__item:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
 }
 
 .sim-top__links {


### PR DESCRIPTION
## Changes - Restructured top bar: Phase + TurnControls grouped as primary strip - Tutorial/help/shortcuts/briefing moved into collapsed utility dropdown menu - Triple-dot trigger button with dropdown overlay - AdvisorDialog remains visible next to utility menu - No functionality removed; only hierarchy and placement changed  ## Testing CSS + JSX layout changes.  Closes #114