### PR TITLE
feat: increase baseline typography size and contrast across simulation dashboard

### DIFF
--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -4,7 +4,7 @@
   --bg-tertiary: #252836;
   --text-primary: #e4e4e7;
   --text-secondary: #a1a1aa;
-  --text-muted: #71717a;
+  --text-muted: #8b8b95;
   --accent-blue: #3b82f6;
   --accent-red: #ef4444;
   --accent-green: #22c55e;
@@ -242,7 +242,7 @@ input, select, textarea, button {
 }
 
 .card__title {
-  font-size: 1rem;
+  font-size: 1.05rem;
   font-weight: 600;
   margin-bottom: 0.5rem;
   color: var(--text-primary);
@@ -494,7 +494,7 @@ input, select, textarea, button {
 }
 
 .phase-indicator__psi {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--text-secondary);
   font-family: 'Courier New', monospace;
 }
@@ -520,7 +520,7 @@ input, select, textarea, button {
 }
 
 .domain-panel__name {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   font-weight: 600;
   display: flex;
   align-items: center;
@@ -535,7 +535,7 @@ input, select, textarea, button {
 }
 
 .domain-panel__value {
-  font-size: 0.78rem;
+  font-size: 0.82rem;
   color: var(--text-secondary);
   font-family: 'Courier New', monospace;
 }
@@ -547,7 +547,7 @@ input, select, textarea, button {
 }
 
 .domain-panel__bar-label {
-  font-size: 0.7rem;
+  font-size: 0.73rem;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -628,7 +628,7 @@ input, select, textarea, button {
   gap: 0.5rem;
   padding: 0.4rem 0.65rem;
   border-radius: 4px;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   line-height: 1.4;
   background: var(--bg-tertiary);
 }
@@ -636,7 +636,7 @@ input, select, textarea, button {
 .event-item__turn {
   color: var(--text-muted);
   font-family: 'Courier New', monospace;
-  font-size: 0.75rem;
+  font-size: 0.78rem;
   flex-shrink: 0;
   min-width: 32px;
 }
@@ -778,17 +778,17 @@ input[type="range"] {
 }
 
 .metric-card--secondary .metric-card__label {
-  font-size: 0.6rem;
+  font-size: 0.65rem;
 }
 
 .metric-card--secondary .metric-card__value {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-secondary);
 }
 
 .metric-card__label {
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -800,7 +800,7 @@ input[type="range"] {
 }
 
 .metric-card__value {
-  font-size: 1.15rem;
+  font-size: 1.25rem;
   font-weight: 700;
   font-family: 'Courier New', monospace;
 }
@@ -811,7 +811,7 @@ input[type="range"] {
   align-items: center;
   padding: 0.15rem 0.5rem;
   border-radius: 999px;
-  font-size: 0.7rem;
+  font-size: 0.73rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -998,7 +998,7 @@ input[type="range"] {
 }
 
 .info-section__heading {
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;


### PR DESCRIPTION
## Changes - --text-muted raised from #71717a to #8b8b95 for better contrast - Metric card labels: 0.7rem -> 0.75rem, values: 1.15rem -> 1.25rem - Secondary metric labels: 0.6rem -> 0.65rem, values: 0.85rem -> 0.9rem - Event feed items: 0.8rem -> 0.85rem, turn badges: 0.75rem -> 0.78rem - Badge text: 0.7rem -> 0.73rem - Phase indicator psi: 0.85rem -> 0.9rem - Domain panel: name 0.85->0.9, value 0.78->0.82, bar-label 0.7->0.73 - Info section headings: 0.7rem -> 0.75rem - Card titles: 1rem -> 1.05rem - Visual identity preserved — sizes are tuned, not redesigned  ## Testing CSS-only changes.  Closes #119