### PR TITLE
feat: separate command surfaces from passive analytics in layout

### DIFF
--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -408,7 +408,7 @@ export default function SimulationDashboard({
         </>
       ) : (
         <div className="sim-panel-container">
-          {/* LEFT: Canvas + Domain Action Bar */}
+          {/* LEFT: Canvas + Command Zone */}
           <div className="sim-panel--canvas">
             <div className="battlespace-canvas">
               <BattlespaceCanvas
@@ -418,15 +418,20 @@ export default function SimulationDashboard({
               />
             </div>
             {myRole !== "observer" && (
-              <DomainActionBar
-                legalActions={legalActions}
-                onDomainClick={(domain) => setActionModalDomain(domain)}
-              />
+              <div className="sim-command-zone">
+                <h3 className="sim-command-zone__heading">Command</h3>
+                <DomainActionBar
+                  legalActions={legalActions}
+                  onDomainClick={(domain) => setActionModalDomain(domain)}
+                />
+              </div>
             )}
           </div>
 
-          {/* RIGHT: Metrics, Chart, Events */}
+          {/* RIGHT: Monitoring & Analytics */}
           <div className="sim-panel--info">
+            <div className="sim-monitor-zone">
+            <h3 className="sim-monitor-zone__heading">Monitoring</h3>
             <div className="info-section">
               <h3 className="info-section__heading">Status</h3>
               <MetricsOverview
@@ -481,6 +486,7 @@ export default function SimulationDashboard({
                   </div>
                 </>
               )}
+            </div>
             </div>
           </div>
         </div>

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -990,6 +990,38 @@ input[type="range"] {
   overflow-y: auto;
 }
 
+/* Command zone */
+.sim-command-zone {
+  border-top: 2px solid var(--accent-blue);
+  padding-top: 0.5rem;
+}
+
+.sim-command-zone__heading {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-blue);
+  margin-bottom: 0.35rem;
+}
+
+/* Monitor zone */
+.sim-monitor-zone {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sim-monitor-zone__heading {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.25rem;
+}
+
 /* Info rail section grouping */
 .info-section {
   display: flex;


### PR DESCRIPTION
## Changes
- Wrapped DomainActionBar in sim-command-zone with accent-blue top border and Command heading
- Wrapped info rail sections in sim-monitor-zone with Monitoring heading and muted bottom border
- Clear visual separation between interactive command surfaces and passive monitoring areas
- No functionality changes

## Testing
CSS + JSX layout changes.

Closes #117