### PR TITLE
feat: add persistent turn-change summary beside turn controls

### DIFF
--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -20,6 +20,7 @@ import CouplingGraph from "./CouplingGraph";
 import AfterActionReport, { DomainDelta, computeDomainDeltas } from "./AfterActionReport";
 import ScenarioBriefing from "./ScenarioBriefing";
 import AdvisorDialog from "./AdvisorDialog";
+import TurnChangeSummary from "./TurnChangeSummary";
 import Dialog from "../common/Dialog";
 import Glossary from "../common/Glossary";
 import { AdvisorSuggestedAction } from "../../types/advisor";
@@ -290,6 +291,15 @@ export default function SimulationDashboard({
             currentTurnEvents={events}
             resources={playerResources}
           />
+          <TurnChangeSummary
+            currentTurn={currentTurn}
+            orderParameter={orderParameter}
+            previousOrderParameter={previousOrderParameter}
+            currentPhase={currentPhase}
+            worldState={worldState}
+            previousWorldState={previousWorldState}
+            events={events}
+          />
         </div>
         <div className="sim-top__secondary">
           {myRole && myRole !== "observer" && (
@@ -362,6 +372,15 @@ export default function SimulationDashboard({
           <div className="sim-mobile-panel">
             {activeMobileTab === "overview" && (
               <>
+                <TurnChangeSummary
+                  currentTurn={currentTurn}
+                  orderParameter={orderParameter}
+                  previousOrderParameter={previousOrderParameter}
+                  currentPhase={currentPhase}
+                  worldState={worldState}
+                  previousWorldState={previousWorldState}
+                  events={events}
+                />
                 <MetricsOverview
                   orderParameter={orderParameter}
                   phase={currentPhase}

--- a/apps/web/src/components/simulation/TurnChangeSummary.tsx
+++ b/apps/web/src/components/simulation/TurnChangeSummary.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+import { ALL_DOMAINS, DomainLayer, DOMAIN_LABELS } from "../../types/domain";
+import { Phase, PHASE_LABELS } from "../../types/phase";
+import { WorldState, TurnEvent } from "../../types/run";
+
+interface TurnChangeSummaryProps {
+  currentTurn: number;
+  orderParameter: number;
+  previousOrderParameter: number;
+  currentPhase: Phase;
+  worldState: WorldState | null;
+  previousWorldState: WorldState | null;
+  events: TurnEvent[];
+}
+
+export default function TurnChangeSummary({
+  currentTurn,
+  orderParameter,
+  previousOrderParameter,
+  currentPhase,
+  worldState,
+  previousWorldState,
+  events,
+}: TurnChangeSummaryProps) {
+  const psiDelta = orderParameter - previousOrderParameter;
+
+  const mostChanged = useMemo<DomainLayer | null>(() => {
+    if (!worldState || !previousWorldState) return null;
+    let maxDelta = 0;
+    let result: DomainLayer | null = null;
+    for (const domain of ALL_DOMAINS) {
+      const curr = worldState.layers[domain]?.stress ?? 0;
+      const prev = previousWorldState.layers[domain]?.stress ?? 0;
+      const delta = Math.abs(curr - prev);
+      if (delta > maxDelta) {
+        maxDelta = delta;
+        result = domain;
+      }
+    }
+    return maxDelta > 0.005 ? result : null;
+  }, [worldState, previousWorldState]);
+
+  const phaseChanged = useMemo(() => {
+    if (!previousWorldState) return false;
+    return previousWorldState.phase !== currentPhase;
+  }, [previousWorldState, currentPhase]);
+
+  const turnEventCount = useMemo(() => {
+    return events.filter((e) => e.turn === currentTurn).length;
+  }, [events, currentTurn]);
+
+  // Don't render on turn 0 or if no previous state
+  if (currentTurn < 1 || !previousWorldState) return null;
+
+  const sign = psiDelta >= 0 ? "+" : "";
+  const psiClass =
+    Math.abs(psiDelta) < 0.005
+      ? ""
+      : psiDelta > 0
+        ? " turn-summary__delta--up"
+        : " turn-summary__delta--down";
+
+  return (
+    <div className="turn-summary">
+      <span className="turn-summary__label">Last turn:</span>
+      <span className={`turn-summary__delta${psiClass}`}>
+        Ψ {sign}{psiDelta.toFixed(2)}
+      </span>
+      {phaseChanged && (
+        <span className="turn-summary__phase-change">
+          → {PHASE_LABELS[currentPhase]}
+        </span>
+      )}
+      {mostChanged && (
+        <span className="turn-summary__domain">
+          ▲ {DOMAIN_LABELS[mostChanged]}
+        </span>
+      )}
+      {turnEventCount > 0 && (
+        <span className="turn-summary__events">
+          {turnEventCount} event{turnEventCount !== 1 ? "s" : ""}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -1297,6 +1297,56 @@ input[type="range"] {
   color: var(--accent-blue);
 }
 
+/* Turn change summary — persistent delta readout */
+.turn-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.turn-summary__label {
+  font-weight: 500;
+  opacity: 0.7;
+}
+
+.turn-summary__delta {
+  font-variant-numeric: tabular-nums;
+}
+
+.turn-summary__delta--up {
+  color: var(--accent-red, #ef4444);
+}
+
+.turn-summary__delta--down {
+  color: var(--accent-green, #22c55e);
+}
+
+.turn-summary__phase-change {
+  color: var(--accent-amber, #f59e0b);
+  font-weight: 600;
+}
+
+.turn-summary__domain {
+  opacity: 0.8;
+}
+
+.turn-summary__events {
+  opacity: 0.7;
+}
+
+@media (max-width: 768px) {
+  .turn-summary {
+    font-size: 0.65rem;
+    gap: 0.3rem;
+  }
+}
+
 .advisor-dialog__actions {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Changes
- New TurnChangeSummary component showing Psi delta, phase change, most-changed domain, event count
- Placed in sim-top__primary after TurnControls (desktop) and in mobile overview tab
- Color-coded: red for Psi increase, green for decrease, amber for phase change
- Compact and subordinate to End Turn button
- Degrades cleanly on mobile with smaller font size

## Testing
CSS + JSX only.

Closes #115