### PR TITLE
feat: add domain focus mode that synchronizes canvas, actions, panels, and events

### DIFF
--- a/apps/web/src/components/simulation/BattlespaceCanvas.tsx
+++ b/apps/web/src/components/simulation/BattlespaceCanvas.tsx
@@ -12,6 +12,7 @@ interface BattlespaceCanvasProps {
   worldState: WorldState | null;
   previousWorldState: WorldState | null;
   onDomainClick?: (domain: DomainLayer) => void;
+  focusedDomain?: DomainLayer | null;
 }
 
 /** Simple seeded PRNG for stable particle positions. */
@@ -72,6 +73,7 @@ export default function BattlespaceCanvas({
   worldState,
   previousWorldState,
   onDomainClick,
+  focusedDomain,
 }: BattlespaceCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -235,11 +237,18 @@ export default function BattlespaceCanvas({
 
       const [dr, dg, db] = hexToRgb(DOMAIN_COLORS[domain]);
       const isHovered = hoveredDomain === domain;
+      const isDimmed = focusedDomain != null && focusedDomain !== domain;
 
       // Zone fill: domain color with minimum visibility + stress-driven intensity
       const fillAlpha = 0.12 + layer.stress * 0.75;
       ctx.fillStyle = `rgba(${dr},${dg},${db},${fillAlpha})`;
       ctx.fillRect(zx, zy, zw, zh);
+
+      // Dim non-focused domains
+      if (isDimmed) {
+        ctx.fillStyle = "rgba(0,0,0,0.55)";
+        ctx.fillRect(zx, zy, zw, zh);
+      }
 
       // Inner glow — brighter bar at bottom proportional to stress
       if (layer.stress > 0.01) {
@@ -401,7 +410,7 @@ export default function BattlespaceCanvas({
         }
       }
     }
-  }, [worldState, previousWorldState, containerWidth, containerHeight, hoveredDomain]);
+  }, [worldState, previousWorldState, containerWidth, containerHeight, hoveredDomain, focusedDomain]);
 
   const fmtPct = (v: number) => `${(v * 100).toFixed(0)}%`;
   const layer = tooltip && worldState ? worldState.layers[tooltip.domain] : null;

--- a/apps/web/src/components/simulation/DomainActionBar.tsx
+++ b/apps/web/src/components/simulation/DomainActionBar.tsx
@@ -16,11 +16,15 @@ const DOMAIN_SHORT: Record<DomainLayer, string> = {
 interface DomainActionBarProps {
   legalActions: LegalAction[];
   onDomainClick: (domain: DomainLayer) => void;
+  focusedDomain?: DomainLayer | null;
+  onFocusDomain?: (domain: DomainLayer | null) => void;
 }
 
 export default function DomainActionBar({
   legalActions,
   onDomainClick,
+  focusedDomain,
+  onFocusDomain,
 }: DomainActionBarProps) {
   return (
     <div className="domain-action-bar" role="toolbar" aria-label="Domain actions">
@@ -34,8 +38,12 @@ export default function DomainActionBar({
         return (
           <button
             key={domain}
-            className={`domain-action-btn${isEmpty ? " domain-action-btn--empty" : ""}`}
+            className={`domain-action-btn${isEmpty ? " domain-action-btn--empty" : ""}${focusedDomain === domain ? " domain-action-btn--focused" : ""}${focusedDomain && focusedDomain !== domain ? " domain-action-btn--dimmed" : ""}`}
             onClick={() => !isEmpty && onDomainClick(domain)}
+            onDoubleClick={(e) => {
+              e.preventDefault();
+              onFocusDomain?.(focusedDomain === domain ? null : domain);
+            }}
             title={`${DOMAIN_LABELS[domain]}${count > 0 ? ` — ${count} actions` : " — no actions"}`}
             aria-disabled={isEmpty}
           >

--- a/apps/web/src/components/simulation/DomainPanel.tsx
+++ b/apps/web/src/components/simulation/DomainPanel.tsx
@@ -30,8 +30,11 @@ interface DomainPanelProps {
   layerState: LayerState | null;
   previousLayerState?: LayerState | null;
   isMostChanged?: boolean;
+  isFocused?: boolean;
+  isDimmed?: boolean;
   couplingMatrix?: Record<string, Record<string, number>>;
   recentEvents?: TurnEvent[];
+  onFocusDomain?: (domain: DomainLayer | null) => void;
 }
 
 function getStressLevel(stress: number): string {
@@ -74,8 +77,11 @@ export default function DomainPanel({
   layerState,
   previousLayerState,
   isMostChanged = false,
+  isFocused = false,
+  isDimmed = false,
   couplingMatrix,
   recentEvents,
+  onFocusDomain,
 }: DomainPanelProps) {
   const [expanded, setExpanded] = useState(false);
   const label = DOMAIN_LABELS[domain];
@@ -112,12 +118,19 @@ export default function DomainPanel({
     isCritical ? "domain-panel--critical" : "",
     expanded ? "domain-panel--expanded" : "",
     !expanded ? "domain-panel--compact" : "",
+    isFocused ? "domain-panel--focused" : "",
+    isDimmed ? "domain-panel--dimmed" : "",
   ].filter(Boolean).join(" ");
 
   return (
     <div
       className={panelClass}
       onClick={() => setExpanded((v) => !v)}
+      onDoubleClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onFocusDomain?.(isFocused ? null : domain);
+      }}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setExpanded((v) => !v); } }}

--- a/apps/web/src/components/simulation/EventFeed.tsx
+++ b/apps/web/src/components/simulation/EventFeed.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { TurnEvent } from "../../types/run";
 import { DomainLayer, DOMAIN_LABELS, ALL_DOMAINS } from "../../types/domain";
 import { EVENT_TYPE_DESCRIPTIONS } from "../../data/glossary";
@@ -7,6 +7,7 @@ import InfoTooltip from "../common/InfoTooltip";
 interface EventFeedProps {
   events: TurnEvent[];
   couplingMatrix?: Record<string, Record<string, number>>;
+  focusedDomain?: DomainLayer | null;
 }
 
 const EVENT_TYPES: TurnEvent["type"][] = [
@@ -125,10 +126,17 @@ const PINNED_TYPES: Set<TurnEvent["type"]> = new Set([
   "phase_transition", "intel", "threat",
 ]);
 
-export default function EventFeed({ events, couplingMatrix }: EventFeedProps) {
+export default function EventFeed({ events, couplingMatrix, focusedDomain }: EventFeedProps) {
   const [activeTypes, setActiveTypes] = useState<Set<TurnEvent["type"]>>(new Set());
   const [activeDomain, setActiveDomain] = useState<DomainLayer | "">("");
   const [searchText, setSearchText] = useState("");
+
+  // Sync external focus with local domain filter
+  useEffect(() => {
+    if (focusedDomain !== undefined) {
+      setActiveDomain(focusedDomain ?? "");
+    }
+  }, [focusedDomain]);
   const [turnRange, setTurnRange] = useState<TurnRange>("all");
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useRunStore } from "../../stores/runStore";
 import { useActions } from "../../hooks/useActions";
-import { ALL_DOMAINS, DomainLayer } from "../../types/domain";
+import { ALL_DOMAINS, DomainLayer, DOMAIN_LABELS } from "../../types/domain";
 import { Role, TurnResult, WorldState } from "../../types/run";
 import { Phase } from "../../types/phase";
 import PhaseIndicator from "./PhaseIndicator";
@@ -139,6 +139,7 @@ export default function SimulationDashboard({
   const [analyticsExpanded, setAnalyticsExpanded] = useState(false);
   const [showUtilMenu, setShowUtilMenu] = useState(false);
   const [actionModalDomain, setActionModalDomain] = useState<DomainLayer | null>(null);
+  const [focusedDomain, setFocusedDomain] = useState<DomainLayer | null>(null);
   const prevWorldStateRef = useRef<WorldState | null>(null);
   const isMountedRef = useRef(true);
   const [activeMobileTab, setActiveMobileTab] =
@@ -266,6 +267,7 @@ export default function SimulationDashboard({
         setShowCouplingGraph(false);
         setShowGlossary(false);
         setActionModalDomain(null);
+        setFocusedDomain(null);
       }
     };
 
@@ -300,6 +302,16 @@ export default function SimulationDashboard({
             previousWorldState={previousWorldState}
             events={events}
           />
+          {focusedDomain && (
+            <button
+              type="button"
+              className="domain-focus-badge"
+              onClick={() => setFocusedDomain(null)}
+              title="Clear domain focus (Esc)"
+            >
+              🔍 {DOMAIN_LABELS[focusedDomain]} <span aria-hidden>✕</span>
+            </button>
+          )}
         </div>
         <div className="sim-top__secondary">
           {myRole && myRole !== "observer" && (
@@ -401,9 +413,11 @@ export default function SimulationDashboard({
                   <DomainActionBar
                     legalActions={legalActions}
                     onDomainClick={(domain) => setActionModalDomain(domain)}
+                    focusedDomain={focusedDomain}
+                    onFocusDomain={setFocusedDomain}
                   />
                 )}
-                <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} />
+                <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} focusedDomain={focusedDomain} />
                 {aiMoves.length > 0 && <AiMovePanel moves={aiMoves} />}
               </>
             )}
@@ -417,8 +431,11 @@ export default function SimulationDashboard({
                     layerState={worldState?.layers[domain] ?? null}
                     previousLayerState={previousWorldState?.layers[domain] ?? null}
                     isMostChanged={domain === mostChangedDomain}
+                    isFocused={focusedDomain === domain}
+                    isDimmed={focusedDomain != null && focusedDomain !== domain}
                     couplingMatrix={worldState?.coupling_matrix}
                     recentEvents={events}
+                    onFocusDomain={setFocusedDomain}
                   />
                 ))}
               </div>
@@ -434,6 +451,7 @@ export default function SimulationDashboard({
                 worldState={worldState}
                 previousWorldState={prevWorldStateRef.current}
                 onDomainClick={myRole !== "observer" ? (domain) => setActionModalDomain(domain) : undefined}
+                focusedDomain={focusedDomain}
               />
             </div>
             {myRole !== "observer" && (
@@ -442,6 +460,8 @@ export default function SimulationDashboard({
                 <DomainActionBar
                   legalActions={legalActions}
                   onDomainClick={(domain) => setActionModalDomain(domain)}
+                  focusedDomain={focusedDomain}
+                  onFocusDomain={setFocusedDomain}
                 />
               </div>
             )}
@@ -472,7 +492,7 @@ export default function SimulationDashboard({
             )}
             <div className="info-section">
               <h3 className="info-section__heading">Events</h3>
-              <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} />
+              <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} focusedDomain={focusedDomain} />
             </div>
             <div className="info-section">
               <button

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -1172,6 +1172,16 @@ input[type="range"] {
   cursor: default;
 }
 
+.domain-action-btn--focused {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.domain-action-btn--dimmed {
+  opacity: 0.3;
+}
+
 .domain-action-btn__dot {
   width: 9px;
   height: 9px;
@@ -3145,6 +3155,35 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
 .domain-panel--expanded {
   border-color: var(--primary, #3b82f6);
   box-shadow: 0 2px 12px rgba(59, 130, 246, 0.15);
+}
+
+.domain-panel--focused {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
+}
+
+.domain-panel--dimmed {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+/* Domain focus badge in header */
+.domain-focus-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+  color: var(--accent-blue);
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid var(--accent-blue);
+  border-radius: 9999px;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.domain-focus-badge:hover {
+  background: rgba(59, 130, 246, 0.2);
 }
 .domain-panel__chevron {
   font-size: 0.7rem;


### PR DESCRIPTION
## Changes
- focusedDomain state in SimulationDashboard, propagated to all child components
- BattlespaceCanvas: non-focused domains dimmed with dark overlay
- DomainActionBar: focused button outlined, non-focused dimmed; double-click to toggle focus
- DomainPanel: focused outlined, non-focused faded with pointer-events disabled; double-click to toggle
- EventFeed: auto-filters to focused domain via synced activeDomain state
- Focus badge in header shows active domain with click-to-clear
- Escape key clears focus globally
- Works with mouse (double-click) and keyboard (Escape)

## Testing
CSS + JSX changes across 6 files.

Closes #123