### PR TITLE
feat: normalize semantic color usage across metrics, badges, and domain accents

### DIFF
--- a/apps/web/src/components/simulation/DomainPanel.tsx
+++ b/apps/web/src/components/simulation/DomainPanel.tsx
@@ -107,10 +107,10 @@ export default function DomainPanel({
     .slice(0, 3);
 
   const stressColor =
-    stressLevel === "critical" ? "#ef4444"
-    : stressLevel === "high" ? "#f97316"
-    : stressLevel === "medium" ? "#eab308"
-    : "#22c55e";
+    stressLevel === "critical" ? "var(--color-danger)"
+    : stressLevel === "high" ? "var(--color-opponent)"
+    : stressLevel === "medium" ? "var(--color-warning)"
+    : "var(--color-success)";
 
   const panelClass = [
     "domain-panel",
@@ -237,7 +237,7 @@ export default function DomainPanel({
             </div>
             <div className="dp-detail-metric">
               <div className="dp-detail-metric__bar">
-                <div className="dp-detail-metric__fill" style={{ width: `${friction * 100}%`, background: "#f59e0b" }} />
+                <div className="dp-detail-metric__fill" style={{ width: `${friction * 100}%`, background: "var(--color-warning)" }} />
               </div>
               <span className="dp-detail-metric__value">{formatPercent(friction)}</span>
             </div>

--- a/apps/web/src/components/simulation/MetricsOverview.tsx
+++ b/apps/web/src/components/simulation/MetricsOverview.tsx
@@ -144,7 +144,7 @@ export default function MetricsOverview({
                 content={
                   <div>
                     <div>Resource points (RP) are spent when executing actions. Each action has a cost.</div>
-                    <div style={{ marginTop: "0.3rem", fontWeight: 600, color: "#22c55e" }}>♻️ Regeneration: +2 RP per turn</div>
+                    <div style={{ marginTop: "0.3rem", fontWeight: 600, color: "var(--color-success)" }}>♻️ Regeneration: +2 RP per turn</div>
                     <div style={{ marginTop: "0.2rem" }}>Running out of RP limits your available actions. Plan resource expenditure carefully.</div>
                   </div>
                 }

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -12,6 +12,18 @@
   --accent-purple: #8b5cf6;
   --border: #2e3044;
   --radius: 8px;
+
+  /* Semantic color roles */
+  --color-cta: #2563eb;           /* Primary CTA — darker blue, distinct from domain */
+  --color-cta-hover: #1d4ed8;
+  --color-danger: #ef4444;        /* Severity: critical, errors, threats */
+  --color-warning: #f59e0b;       /* Severity: caution, degraded */
+  --color-success: #22c55e;       /* Positive: stable, resolved */
+  --color-info: #38bdf8;          /* Informational: neutral highlights */
+  --color-opponent: #f97316;      /* Opponent / AI actions */
+  --color-coupling: #a78bfa;      /* Coupling / cross-domain effects */
+  --color-intel: #34d399;         /* Intel events */
+  --color-sitrep: #14b8a6;        /* Narrative / SITREP */
 }
 
 *,
@@ -342,19 +354,19 @@ input, select, textarea, button {
 }
 
 .btn--primary {
-  background: var(--accent-blue);
-  border-color: var(--accent-blue);
+  background: var(--color-cta);
+  border-color: var(--color-cta);
   color: #fff;
 }
 
 .btn--primary:hover {
-  background: #2563eb;
-  border-color: #2563eb;
+  background: var(--color-cta-hover);
+  border-color: var(--color-cta-hover);
 }
 
 .btn--danger {
-  background: var(--accent-red);
-  border-color: var(--accent-red);
+  background: var(--color-danger);
+  border-color: var(--color-danger);
   color: #fff;
 }
 
@@ -363,8 +375,8 @@ input, select, textarea, button {
 }
 
 .btn--success {
-  background: var(--accent-green);
-  border-color: var(--accent-green);
+  background: var(--color-success);
+  border-color: var(--color-success);
   color: #fff;
 }
 
@@ -818,28 +830,28 @@ input[type="range"] {
 }
 
 .badge--blue {
-  background: rgba(59, 130, 246, 0.15);
-  color: var(--accent-blue);
+  background: rgba(37, 99, 235, 0.15);
+  color: var(--color-cta);
 }
 
 .badge--red {
   background: rgba(239, 68, 68, 0.15);
-  color: var(--accent-red);
+  color: var(--color-danger);
 }
 
 .badge--green {
-  background: rgba(34, 197, 94, 0.15);
-  color: var(--accent-green);
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--color-intel);
 }
 
 .badge--yellow {
-  background: rgba(234, 179, 8, 0.15);
-  color: var(--accent-yellow);
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--color-warning);
 }
 
 .badge--purple {
-  background: rgba(139, 92, 246, 0.15);
-  color: var(--accent-purple);
+  background: rgba(167, 139, 250, 0.15);
+  color: var(--color-coupling);
 }
 
 .badge--gray {
@@ -849,12 +861,12 @@ input[type="range"] {
 
 .badge--orange {
   background: rgba(249, 115, 22, 0.15);
-  color: #f97316;
+  color: var(--color-opponent);
 }
 
 .badge--teal {
   background: rgba(20, 184, 166, 0.15);
-  color: #14b8a6;
+  color: var(--color-sitrep);
 }
 
 /* Player list */
@@ -2138,8 +2150,8 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
   font-weight: 600;
   font-family: monospace;
 }
-.effect-pill--stress-up   { background: rgba(239,68,68,0.15); color: #fca5a5; }
-.effect-pill--stress-down { background: rgba(34,197,94,0.15);  color: #86efac; }
+.effect-pill--stress-up   { background: rgba(239,68,68,0.15); color: var(--color-danger); }
+.effect-pill--stress-down { background: rgba(34,197,94,0.15);  color: var(--color-success); }
 .effect-pill--resilience-up   { background: rgba(34,197,94,0.15);  color: #86efac; }
 .effect-pill--resilience-down { background: rgba(239,68,68,0.15); color: #fca5a5; }
 .effect-pill--activity { background: rgba(59,130,246,0.15); color: #93c5fd; }


### PR DESCRIPTION
## Changes
- Added semantic CSS variables: --color-cta, --color-danger, --color-warning, --color-success, --color-info, --color-opponent, --color-coupling, --color-intel, --color-sitrep
- CTA button uses --color-cta (#2563eb) — darker blue, distinct from Maritime domain color (#3b82f6)
- Badges use semantic variables instead of raw accent colors
- DomainPanel stress colors use semantic vars instead of hardcoded hex
- MetricsOverview regeneration text uses --color-success
- Effect pills use semantic vars for stress-up/down
- Domain identity colors remain unchanged

## Testing
CSS variable changes + inline style updates in 3 files.

Closes #124