### PR TITLE
feat: add compact vs analyst display modes for simulation telemetry

### DIFF
--- a/apps/web/src/components/simulation/EventFeed.tsx
+++ b/apps/web/src/components/simulation/EventFeed.tsx
@@ -8,6 +8,7 @@ interface EventFeedProps {
   events: TurnEvent[];
   couplingMatrix?: Record<string, Record<string, number>>;
   focusedDomain?: DomainLayer | null;
+  compact?: boolean;
 }
 
 const EVENT_TYPES: TurnEvent["type"][] = [
@@ -126,7 +127,7 @@ const PINNED_TYPES: Set<TurnEvent["type"]> = new Set([
   "phase_transition", "intel", "threat",
 ]);
 
-export default function EventFeed({ events, couplingMatrix, focusedDomain }: EventFeedProps) {
+export default function EventFeed({ events, couplingMatrix, focusedDomain, compact }: EventFeedProps) {
   const [activeTypes, setActiveTypes] = useState<Set<TurnEvent["type"]>>(new Set());
   const [activeDomain, setActiveDomain] = useState<DomainLayer | "">("");
   const [searchText, setSearchText] = useState("");
@@ -199,6 +200,7 @@ export default function EventFeed({ events, couplingMatrix, focusedDomain }: Eve
       </div>
 
       {/* Filter bar */}
+      {!compact && (
       <div className="ef-filters">
         <input
           type="text"
@@ -253,6 +255,7 @@ export default function EventFeed({ events, couplingMatrix, focusedDomain }: Eve
           )}
         </div>
       </div>
+      )}
 
       {/* Event list */}
       <div className="event-feed mt-1">
@@ -261,7 +264,7 @@ export default function EventFeed({ events, couplingMatrix, focusedDomain }: Eve
             {events.length === 0 ? "No events yet." : "No events match filters."}
           </div>
         ) : (
-          filteredEvents.map((event, idx) => {
+          (compact ? filteredEvents.slice(0, 5) : filteredEvents).map((event, idx) => {
             const badge = getTypeBadge(event.type);
             const domainLabel = getDomainLabel(event.domain);
             const isNew = idx < 3;

--- a/apps/web/src/components/simulation/MetricsOverview.tsx
+++ b/apps/web/src/components/simulation/MetricsOverview.tsx
@@ -13,6 +13,7 @@ interface MetricsOverviewProps {
   side?: "blue" | "red";
   previousOrderParameter?: number;
   previousWorldState?: WorldState | null;
+  compact?: boolean;
 }
 
 function findPlayerResources(
@@ -56,6 +57,7 @@ export default function MetricsOverview({
   side,
   previousOrderParameter,
   previousWorldState,
+  compact,
 }: MetricsOverviewProps) {
   let dominantDomain: DomainLayer | null = null;
   let maxStress = 0;
@@ -157,7 +159,8 @@ export default function MetricsOverview({
           </div>
         )}
       </div>
-      {/* Secondary: supporting telemetry */}
+      {/* Secondary: supporting telemetry (hidden in compact mode) */}
+      {!compact && (
       <div className="metrics-grid metrics-grid--secondary">
         <div className="metric-card metric-card--secondary">
           <div className="metric-card__label">Turn</div>
@@ -187,6 +190,7 @@ export default function MetricsOverview({
           </div>
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/simulation/SimulationDashboard.tsx
+++ b/apps/web/src/components/simulation/SimulationDashboard.tsx
@@ -36,6 +36,26 @@ interface AarData {
 }
 
 type MobileTab = "overview" | "actions" | "domains";
+type DisplayMode = "compact" | "analyst";
+
+const DISPLAY_MODE_KEY = "greyzone:displayMode";
+
+function useDisplayMode(): [DisplayMode, (mode: DisplayMode) => void] {
+  const [mode, setModeState] = useState<DisplayMode>(() => {
+    try {
+      const stored = localStorage.getItem(DISPLAY_MODE_KEY);
+      if (stored === "compact" || stored === "analyst") return stored;
+    } catch { /* ignore */ }
+    return "compact";
+  });
+
+  const setMode = (next: DisplayMode) => {
+    setModeState(next);
+    try { localStorage.setItem(DISPLAY_MODE_KEY, next); } catch { /* ignore */ }
+  };
+
+  return [mode, setMode];
+}
 
 function useMediaQuery(query: string) {
   const [matches, setMatches] = useState(() =>
@@ -137,6 +157,7 @@ export default function SimulationDashboard({
   const [showCouplingGraph, setShowCouplingGraph] = useState(false);
   const [showGlossary, setShowGlossary] = useState(false);
   const [analyticsExpanded, setAnalyticsExpanded] = useState(false);
+  const [displayMode, setDisplayMode] = useDisplayMode();
   const [showUtilMenu, setShowUtilMenu] = useState(false);
   const [actionModalDomain, setActionModalDomain] = useState<DomainLayer | null>(null);
   const [focusedDomain, setFocusedDomain] = useState<DomainLayer | null>(null);
@@ -314,6 +335,14 @@ export default function SimulationDashboard({
           )}
         </div>
         <div className="sim-top__secondary">
+          <button
+            type="button"
+            className="btn btn--sm btn--ghost sim-display-toggle"
+            onClick={() => setDisplayMode(displayMode === "compact" ? "analyst" : "compact")}
+            title={displayMode === "compact" ? "Switch to analyst mode" : "Switch to compact mode"}
+          >
+            {displayMode === "compact" ? "▦ Analyst" : "▤ Compact"}
+          </button>
           {myRole && myRole !== "observer" && (
             <AdvisorDialog
               runId={runId}
@@ -402,8 +431,11 @@ export default function SimulationDashboard({
                   side={side}
                   previousOrderParameter={previousOrderParameter}
                   previousWorldState={previousWorldState}
+                  compact={displayMode === "compact"}
                 />
-                <DomainStressChart stressHistory={stressHistory} psiHistory={psiHistory} />
+                {displayMode === "analyst" && (
+                  <DomainStressChart stressHistory={stressHistory} psiHistory={psiHistory} />
+                )}
               </>
             )}
 
@@ -482,6 +514,7 @@ export default function SimulationDashboard({
                 side={side}
                 previousOrderParameter={previousOrderParameter}
                 previousWorldState={previousWorldState}
+                compact={displayMode === "compact"}
               />
             </div>
             {aiMoves.length > 0 && (
@@ -492,8 +525,9 @@ export default function SimulationDashboard({
             )}
             <div className="info-section">
               <h3 className="info-section__heading">Events</h3>
-              <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} focusedDomain={focusedDomain} />
+              <EventFeed events={events} couplingMatrix={worldState?.coupling_matrix} focusedDomain={focusedDomain} compact={displayMode === "compact"} />
             </div>
+            {displayMode === "analyst" && (
             <div className="info-section">
               <button
                 type="button"
@@ -526,6 +560,7 @@ export default function SimulationDashboard({
                 </>
               )}
             </div>
+            )}
             </div>
           </div>
         </div>

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -4308,6 +4308,19 @@ input[type="range"]::-moz-range-thumb { width: 16px; height: 16px; border-radius
 
 /* ===== END SIMULATION SPEC PAGE ===== */
 
+/* ===== DISPLAY MODE TOGGLE ===== */
+.sim-display-toggle {
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  opacity: 0.8;
+  transition: opacity 0.15s ease;
+}
+.sim-display-toggle:hover {
+  opacity: 1;
+}
+/* ===== END DISPLAY MODE TOGGLE ===== */
+
 /* ===== TOUCH-TARGET SIZING (tablet / mobile) ===== */
 @media (max-width: 1024px) {
   /* Base buttons: 44px minimum touch target */


### PR DESCRIPTION
## Changes
- Added display mode toggle (compact/analyst) persisted in localStorage
- Toggle button in top bar secondary area — minimal, ghost style
- **Compact mode**: hides secondary metrics grid, event feed filters, analytics section; limits events to latest 5
- **Analyst mode**: shows full telemetry — all metrics, filters, analytics with expand/collapse
- New compact prop on MetricsOverview (hides secondary grid) and EventFeed (hides filters, limits to 5 events)
- Mobile view: compact mode hides DomainStressChart from overview tab
- CSS for toggle button with subtle opacity hover effect

## Testing
\\\ash
cd apps/web
npx -p typescript tsc --noEmit  # Only pre-existing type def warnings
\\\

Closes #126